### PR TITLE
Rephrased meta.time format in all event types.

### DIFF
--- a/eiffel-vocabulary/EiffelActivityCanceledEvent.md
+++ b/eiffel-vocabulary/EiffelActivityCanceledEvent.md
@@ -71,7 +71,7 @@ __Description:__ The version of the event type. This field is required by the re
 
 ### meta.time
 __Type:__ Integer  
-__Format:__ Milliseconds since epoch.  
+__Format:__ UNIX Epoch time, in milliseconds.  
 __Required:__ Yes  
 __Description:__ The event creation timestamp.
 

--- a/eiffel-vocabulary/EiffelActivityFinishedEvent.md
+++ b/eiffel-vocabulary/EiffelActivityFinishedEvent.md
@@ -103,7 +103,7 @@ __Description:__ The version of the event type. This field is required by the re
 
 ### meta.time
 __Type:__ Integer  
-__Format:__ Milliseconds since epoch.  
+__Format:__ UNIX Epoch time, in milliseconds.  
 __Required:__ Yes  
 __Description:__ The event creation timestamp.
 

--- a/eiffel-vocabulary/EiffelActivityStartedEvent.md
+++ b/eiffel-vocabulary/EiffelActivityStartedEvent.md
@@ -92,7 +92,7 @@ __Description:__ The version of the event type. This field is required by the re
 
 ### meta.time
 __Type:__ Integer  
-__Format:__ Milliseconds since epoch.  
+__Format:__ UNIX Epoch time, in milliseconds.  
 __Required:__ Yes  
 __Description:__ The event creation timestamp.
 

--- a/eiffel-vocabulary/EiffelActivityTriggeredEvent.md
+++ b/eiffel-vocabulary/EiffelActivityTriggeredEvent.md
@@ -99,7 +99,7 @@ __Description:__ The version of the event type. This field is required by the re
 
 ### meta.time
 __Type:__ Integer  
-__Format:__ Milliseconds since epoch.  
+__Format:__ UNIX Epoch time, in milliseconds.  
 __Required:__ Yes  
 __Description:__ The event creation timestamp.
 

--- a/eiffel-vocabulary/EiffelAnnouncementPublishedEvent.md
+++ b/eiffel-vocabulary/EiffelAnnouncementPublishedEvent.md
@@ -87,7 +87,7 @@ __Description:__ The version of the event type. This field is required by the re
 
 ### meta.time
 __Type:__ Integer  
-__Format:__ Milliseconds since epoch.  
+__Format:__ UNIX Epoch time, in milliseconds.  
 __Required:__ Yes  
 __Description:__ The event creation timestamp.
 

--- a/eiffel-vocabulary/EiffelArtifactCreatedEvent.md
+++ b/eiffel-vocabulary/EiffelArtifactCreatedEvent.md
@@ -173,7 +173,7 @@ __Description:__ The version of the event type. This field is required by the re
 
 ### meta.time
 __Type:__ Integer  
-__Format:__ Milliseconds since epoch.  
+__Format:__ UNIX Epoch time, in milliseconds.  
 __Required:__ Yes  
 __Description:__ The event creation timestamp.
 

--- a/eiffel-vocabulary/EiffelArtifactPublishedEvent.md
+++ b/eiffel-vocabulary/EiffelArtifactPublishedEvent.md
@@ -86,7 +86,7 @@ __Description:__ The version of the event type. This field is required by the re
 
 ### meta.time
 __Type:__ Integer  
-__Format:__ Milliseconds since epoch.  
+__Format:__ UNIX Epoch time, in milliseconds.  
 __Required:__ Yes  
 __Description:__ The event creation timestamp.
 

--- a/eiffel-vocabulary/EiffelArtifactReusedEvent.md
+++ b/eiffel-vocabulary/EiffelArtifactReusedEvent.md
@@ -75,7 +75,7 @@ __Description:__ The version of the event type. This field is required by the re
 
 ### meta.time
 __Type:__ Integer  
-__Format:__ Milliseconds since epoch.  
+__Format:__ UNIX Epoch time, in milliseconds.  
 __Required:__ Yes  
 __Description:__ The event creation timestamp.
 

--- a/eiffel-vocabulary/EiffelCompositionDefinedEvent.md
+++ b/eiffel-vocabulary/EiffelCompositionDefinedEvent.md
@@ -84,7 +84,7 @@ __Description:__ The version of the event type. This field is required by the re
 
 ### meta.time
 __Type:__ Integer  
-__Format:__ Milliseconds since epoch.  
+__Format:__ UNIX Epoch time, in milliseconds.  
 __Required:__ Yes  
 __Description:__ The event creation timestamp.
 

--- a/eiffel-vocabulary/EiffelConfidenceLevelModifiedEvent.md
+++ b/eiffel-vocabulary/EiffelConfidenceLevelModifiedEvent.md
@@ -117,7 +117,7 @@ __Description:__ The version of the event type. This field is required by the re
 
 ### meta.time
 __Type:__ Integer  
-__Format:__ Milliseconds since epoch.  
+__Format:__ UNIX Epoch time, in milliseconds.  
 __Required:__ Yes  
 __Description:__ The event creation timestamp.
 

--- a/eiffel-vocabulary/EiffelEnvironmentDefinedEvent.md
+++ b/eiffel-vocabulary/EiffelEnvironmentDefinedEvent.md
@@ -103,7 +103,7 @@ __Description:__ The version of the event type. This field is required by the re
 
 ### meta.time
 __Type:__ Integer  
-__Format:__ Milliseconds since epoch.  
+__Format:__ UNIX Epoch time, in milliseconds.  
 __Required:__ Yes  
 __Description:__ The event creation timestamp.
 

--- a/eiffel-vocabulary/EiffelFlowContextDefinedEvent.md
+++ b/eiffel-vocabulary/EiffelFlowContextDefinedEvent.md
@@ -87,7 +87,7 @@ __Description:__ The version of the event type. This field is required by the re
 
 ### meta.time
 __Type:__ Integer  
-__Format:__ Milliseconds since epoch.  
+__Format:__ UNIX Epoch time, in milliseconds.  
 __Required:__ Yes  
 __Description:__ The event creation timestamp.
 

--- a/eiffel-vocabulary/EiffelIssueDefinedEvent.md
+++ b/eiffel-vocabulary/EiffelIssueDefinedEvent.md
@@ -116,7 +116,7 @@ recipient of the event to interpret the contents. Please see
 
 ### meta.time
 __Type:__ Integer  
-__Format:__ Milliseconds since epoch.  
+__Format:__ UNIX Epoch time, in milliseconds.  
 __Required:__ Yes  
 __Description:__ The event creation timestamp.
 

--- a/eiffel-vocabulary/EiffelIssueVerifiedEvent.md
+++ b/eiffel-vocabulary/EiffelIssueVerifiedEvent.md
@@ -101,7 +101,7 @@ __Description:__ The version of the event type. This field is required by the re
 
 ### meta.time
 __Type:__ Integer  
-__Format:__ Milliseconds since epoch.  
+__Format:__ UNIX Epoch time, in milliseconds.  
 __Required:__ Yes  
 __Description:__ The event creation timestamp.
 

--- a/eiffel-vocabulary/EiffelSourceChangeCreatedEvent.md
+++ b/eiffel-vocabulary/EiffelSourceChangeCreatedEvent.md
@@ -199,7 +199,7 @@ __Description:__ Identifies an issue that this event partially resolves. That is
 __Required:__ No  
 __Legal targets:__ [EiffelIssueDefinedEvent](../eiffel-vocabulary/EiffelIssueDefinedEvent.md)  
 __Multiple allowed:__ Yes  
-__Description:__ Identifies an issue that this SCC is claiming it has done enough to resolve. This is not an authoritative resolution, only a claim. The issue may or may not change status as a consequence this, e.g. through a [successful verification](../eiffel-vocabular/EiffelIssueVerifiedEvent.md) or a manual update on the issue tracker. 
+__Description:__ Identifies an issue that this SCC is claiming it has done enough to resolve. This is not an authoritative resolution, only a claim. The issue may or may not change status as a consequence this, e.g. through a [successful verification](../eiffel-vocabular/EiffelIssueVerifiedEvent.md) or a manual update on the issue tracker.
 
 ### DERESOLVED_ISSUE
 __Required:__ No  
@@ -247,7 +247,7 @@ __Description:__ The version of the event type. This field is required by the re
 
 ### meta.time
 __Type:__ Integer  
-__Format:__ Milliseconds since epoch.  
+__Format:__ UNIX Epoch time, in milliseconds.  
 __Required:__ Yes  
 __Description:__ The event creation timestamp.
 

--- a/eiffel-vocabulary/EiffelSourceChangeSubmittedEvent.md
+++ b/eiffel-vocabulary/EiffelSourceChangeSubmittedEvent.md
@@ -196,7 +196,7 @@ __Description:__ The version of the event type. This field is required by the re
 
 ### meta.time
 __Type:__ Integer  
-__Format:__ Milliseconds since epoch.  
+__Format:__ UNIX Epoch time, in milliseconds.  
 __Required:__ Yes  
 __Description:__ The event creation timestamp.
 

--- a/eiffel-vocabulary/EiffelTestCaseCanceledEvent.md
+++ b/eiffel-vocabulary/EiffelTestCaseCanceledEvent.md
@@ -71,7 +71,7 @@ __Description:__ The version of the event type. This field is required by the re
 
 ### meta.time
 __Type:__ Integer  
-__Format:__ Milliseconds since epoch.  
+__Format:__ UNIX Epoch time, in milliseconds.  
 __Required:__ Yes  
 __Description:__ The event creation timestamp.
 

--- a/eiffel-vocabulary/EiffelTestCaseFinishedEvent.md
+++ b/eiffel-vocabulary/EiffelTestCaseFinishedEvent.md
@@ -130,7 +130,7 @@ __Description:__ The version of the event type. This field is required by the re
 
 ### meta.time
 __Type:__ Integer  
-__Format:__ Milliseconds since epoch.  
+__Format:__ UNIX Epoch time, in milliseconds.  
 __Required:__ Yes  
 __Description:__ The event creation timestamp.
 

--- a/eiffel-vocabulary/EiffelTestCaseStartedEvent.md
+++ b/eiffel-vocabulary/EiffelTestCaseStartedEvent.md
@@ -93,7 +93,7 @@ __Description:__ The version of the event type. This field is required by the re
 
 ### meta.time
 __Type:__ Integer  
-__Format:__ Milliseconds since epoch.  
+__Format:__ UNIX Epoch time, in milliseconds.  
 __Required:__ Yes  
 __Description:__ The event creation timestamp.
 

--- a/eiffel-vocabulary/EiffelTestCaseTriggeredEvent.md
+++ b/eiffel-vocabulary/EiffelTestCaseTriggeredEvent.md
@@ -141,7 +141,7 @@ __Description:__ The version of the event type. This field is required by the re
 
 ### meta.time
 __Type:__ Integer  
-__Format:__ Milliseconds since epoch.  
+__Format:__ UNIX Epoch time, in milliseconds.  
 __Required:__ Yes  
 __Description:__ The event creation timestamp.
 

--- a/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md
+++ b/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md
@@ -168,7 +168,7 @@ __Description:__ The version of the event type. This field is required by the re
 
 ### meta.time
 __Type:__ Integer  
-__Format:__ Milliseconds since epoch.  
+__Format:__ UNIX Epoch time, in milliseconds.  
 __Required:__ Yes  
 __Description:__ The event creation timestamp.
 

--- a/eiffel-vocabulary/EiffelTestSuiteFinishedEvent.md
+++ b/eiffel-vocabulary/EiffelTestSuiteFinishedEvent.md
@@ -113,7 +113,7 @@ __Description:__ The version of the event type. This field is required by the re
 
 ### meta.time
 __Type:__ Integer  
-__Format:__ Milliseconds since epoch.  
+__Format:__ UNIX Epoch time, in milliseconds.  
 __Required:__ Yes  
 __Description:__ The event creation timestamp.
 

--- a/eiffel-vocabulary/EiffelTestSuiteStartedEvent.md
+++ b/eiffel-vocabulary/EiffelTestSuiteStartedEvent.md
@@ -99,7 +99,7 @@ __Description:__ The version of the event type. This field is required by the re
 
 ### meta.time
 __Type:__ Integer  
-__Format:__ Milliseconds since epoch.  
+__Format:__ UNIX Epoch time, in milliseconds.  
 __Required:__ Yes  
 __Description:__ The event creation timestamp.
 


### PR DESCRIPTION
As per issue #177, clarified the description of meta.time
format for all event types. No stepping of event versions
required as the actual event syntax is unaffected by this change.

### Applicable Issues
#177

### Description of the Change
Changed the format of meta.time for all event types to "UNIX Epoch time, in milliseconds."

### Alternate Designs
As discussed in #177.

### Benefits
Less room for misinterpretation.

### Possible Drawbacks
n/a

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Daniel Ståhl daniel.stahl@ericsson.com
