### PR TITLE
Remove duplicate id field in ArtifactReusedEvent

### DIFF
--- a/examples/events/EiffelArtifactReusedEvent/simple.json
+++ b/examples/events/EiffelArtifactReusedEvent/simple.json
@@ -8,7 +8,6 @@
       "domainId": "example.domain",
       "serializer": "pkg:maven/com.mycompany.tools/eiffel-serializer@1.0.3"
     },
-    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0",
     "tags": [
       "fast-track",
       "customer-a"


### PR DESCRIPTION

### Applicable Issues
The example event contained a duplicate id field, making it an invalid Eiffel event.

### Description of the Change
Removed the duplicate field.

### Alternate Designs
N/A

### Benefits
Valid Eiffel event in the examples. 

### Possible Drawbacks
None

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Emelie Pettersson emelie.pettersson@ericsson.com
