### PR TITLE
Adding a configuration field to TERCC.

### DIFF
--- a/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md
+++ b/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md
@@ -1,5 +1,5 @@
 <!---
-   Copyright 2017-2018 Ericsson AB.
+   Copyright 2017-2020 Ericsson AB and others.
    For a full list of individual contributors, please see the commit history.
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,7 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
---->
+-->
 
 # EiffelTestExecutionRecipeCollectionCreatedEvent (TERCC)
 The EiffelTestExecutionRecipeCollectionCreatedEvent declares that a collection of test execution recipes has been created. In order to clarify what that means, several concepts need to be explained.
@@ -24,7 +24,10 @@ How the test selection service generates the recipe collection is, from the poin
 
 The __data__ object consists of two main parts. __data.selectionStrategy__ identifies the strategy used to select the test cases and generate the recipe collection, while __data.batches__ or __data.batchesUri__ contain or reference, respectively, the recipes. The recipes are grouped in batches, which are used to control the order of execution of test cases. Every batch has a priority to let the test executor order them in sequence, but within each batch no assumptions are made as to the execution order the test cases. This way the recipe collection can either allow the executor a high degree of freedom in scheduling the test executions, and/or prescribe the exact sequential order in which they must be executed. Each event SHALL include one and only one of __data.batches__ and __data.batchesUri__.
 
-Finally, each recipe (__data.batches.recipes__) consists of two parts: the test case to execute, and the constraints of that execution. The EiffelTestExecutionRecipeCollectionCreatedEvent does not control the syntax of these constraints, as the nature of such constraints are highly dependent on technology domain and test execution framework. That being said, there are three questions that typically need to be answered: what is the item under test, in what kind of environment is it to be tested, and what are the test parameters? Note the distinction between test case and test execution: it is perfectly legal for a single test case to appear multiple times within the same EiffelTestExecutionRecipeCollectionCreatedEvent, but (presumably) with different constraints.
+Each recipe (__data.batches.recipes__) consists of two parts: the test case to execute, and the constraints of that execution. The EiffelTestExecutionRecipeCollectionCreatedEvent does not control the syntax of these constraints, as the nature of such constraints are highly dependent on technology domain and test execution framework. That being said, there are three questions that typically need to be answered: what is the item under test, in what kind of environment is it to be tested, and what are the test parameters? Note the distinction between test case and test execution: it is perfectly legal for a single test case to appear multiple times within the same EiffelTestExecutionRecipeCollectionCreatedEvent, but (presumably) with different constraints.
+
+There are constraints both on batch-level as well as on recipe-level, the batch-level constraints shall apply on every single recipe in the batch while the recipe-level only apply on a single recipe. Both constraints can include the same information and care needs to be taken when both are used. The easiest would be to never cross constraints between batch-level and recipe-level and try to keep them separate as much as possible. If there are scenarios where the same constraint is used, recipe-level should be the one that is used; but this is highly dependent on technology domain and test execution framework as there might be reasons to use the batch-level constraint in this case.
+
 
 ## Data Members
 ### data.selectionStrategy
@@ -67,6 +70,21 @@ __Type:__ Integer
 __Required:__ Yes  
 __Description:__ The execution priority of the batch, as compared to other batches in the collection. A lower value SHALL be interpreted as a higher priority.
 
+#### data.batches.constraints
+__Type:__ Object[]
+__Required:__ No
+__Description:__ Any constraints of the batch. The nature of such constraints is highly dependent on technology domain and test execution framework. Consequently, there are no pre-defined or required constraints. Instead, this property is a list of key-value pairs on the same format as [data.customData](../customization/custom-data.md). That being said, there are three questions that typically need to be answered: what is the item under test, in what kind of environment is it to be tested, and what are the test parameters? Note that this is per-batch constraints and will apply to all recipes in the batch. Not to be confused with __data.batches.recipes.constraints__ which apply to only a single recipe.
+
+###### data.batches.constraints.key
+__Type:__ String
+__Required:__ Yes
+__Description:__ The key name of the constraint.
+
+###### data.batches.constraints.value
+__Type:__ Any
+__Required:__ Yes
+__Description:__ The value of the constraint.
+
 #### data.batches.recipes
 __Type:__ Object[]  
 __Required:__ Yes  
@@ -100,7 +118,7 @@ __Description:__ A location where a description of the test case can be retrieve
 ##### data.batches.recipes.constraints
 __Type:__ Object[]  
 __Required:__ No  
-__Description:__ Any constraints of the execution. The nature of such constraints is highly dependent on technology domain and test execution framework. Consequently, there are no pre-defined or required constraints. Instead, this property is a list of key-value pairs on the same format as [data.customData](../customization/custom-data.md). That being said, there are three questions that typically need to be answered: what is the item under test, in what kind of environment is it to be tested, and what are the test parameters?
+__Description:__ Any constraints of the execution. The nature of such constraints is highly dependent on technology domain and test execution framework. Consequently, there are no pre-defined or required constraints. Instead, this property is a list of key-value pairs on the same format as [data.customData](../customization/custom-data.md). That being said, there are three questions that typically need to be answered: what is the item under test, in what kind of environment is it to be tested, and what are the test parameters? Note that this is per-recipe constraints and will apply to only a single recipe in the batch. Not to be confused with __data.batches.constraints__ which apply to all recipes.
 
 ###### data.batches.recipes.constraints.key
 __Type:__ String  

--- a/schemas/EiffelTestExecutionRecipeCollectionCreatedEvent/4.1.0.json
+++ b/schemas/EiffelTestExecutionRecipeCollectionCreatedEvent/4.1.0.json
@@ -1,0 +1,295 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [ "EiffelTestExecutionRecipeCollectionCreatedEvent" ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [ "4.1.0" ],
+          "default": "4.1.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "selectionStrategy": {
+          "type": "object",
+          "properties": {
+            "tracker": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "additionalProperties": false
+        },
+        "batchesUri": {
+          "type": "string"
+        },
+        "batches": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "priority": {
+                "type": "integer"
+              },
+	      "constraints": {
+	        "type": "array",
+	        "items": {
+	          "type": "object",
+	          "properties": {
+	            "key": {
+	              "type": "string"
+	            },
+	            "value": {
+	            }
+	          },
+	          "required": [
+	            "key",
+	            "value"
+	          ],
+	          "additionalProperties": false
+	        }
+	      },
+              "recipes": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+                    },
+                    "testCase": {
+                      "type": "object",
+                      "properties": {
+                        "tracker": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "uri": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "constraints": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "value": {
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "value"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "testCase"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "dependencies": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "dependent": {
+                      "type": "string"
+                    },
+                    "dependency": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "dependent",
+                    "dependency"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "priority",
+              "recipes"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {
+              }
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "selectionStrategy"
+      ],
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
Not sure if we add new json schemas in PR like this, so i added one. Please inform me if that should be removed.
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
fixes: #241 

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
This configuration field will be used for batch-level configuration
of a test suite. This is not to be confused with the constraints field
which is for a recipe-level configuration.


### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
Today we are using 'data.cusomData' for the same feature, but customData should be avoided.

### Benefits
<!-- What benefits will be realized by the change? -->
Avoiding the usage of the customData field is always a benefit.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
Not sure if this field will be usable by others. Might add unnecessary clutter.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobiaspn@axis.com>
