### PR TITLE
Graduate this project

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@
 
 <img src="./images/eiffel-protocol-logo.png" alt="Eiffel Protocol" width="350"/>
 
-.. image:: https://img.shields.io/badge/Stage-Graduated-green
-  :target: https://github.com/eiffel-community/community/blob/master/PROJECT_LIFECYCLE.md#stage-graduated
+[![Graduated](https://img.shields.io/badge/Stage-Graduated-green)](https://github.com/eiffel-community/community/blob/master/PROJECT_LIFECYCLE.md#stage-graduated)
 
 # Eiffel Protocol
 This repository contains the Eiffel protocol vocabulary, descriptions, guides and schemas. For implementations, architecture and community resources, visit the [Eiffel Community](https://eiffel-community.github.io).

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@
 
 <img src="./images/eiffel-protocol-logo.png" alt="Eiffel Protocol" width="350"/>
 
+.. image:: https://img.shields.io/badge/Stage-Graduated-green
+  :target: https://github.com/eiffel-community/community/blob/master/PROJECT_LIFECYCLE.md#stage-graduated
+
 # Eiffel Protocol
 This repository contains the Eiffel protocol vocabulary, descriptions, guides and schemas. For implementations, architecture and community resources, visit the [Eiffel Community](https://eiffel-community.github.io).
 


### PR DESCRIPTION
### Applicable Issues
[Community Issue 77](https://github.com/eiffel-community/community/issues/77) with [Community PR 78](https://github.com/eiffel-community/community/pull/78)

### Description of the Change
This transitions the Eiffel Protocol to become 'Graduated'

### Alternate Designs
None

### Benefits
As the protocol is the base of everything in Eiffel, it needs to be graduated

### Possible Drawbacks
None

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Emil Bäckmark, emil.backmark@ericsson.com