### PR TITLE
validate.py: Replace deprecated time.clock() calls

### DIFF
--- a/examples/validate.py
+++ b/examples/validate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2017 Ericsson AB.
 # For a full list of individual contributors, please see the commit history.
@@ -90,7 +90,7 @@ def validateExamples(examples, schemas, maxExamples, shuffle):
   unchecked = []
 
   numChecked = 0
-  latestReportTime = time.clock()
+  latestReportTime = time.perf_counter()
   
   if shuffle:
     random.shuffle(examples)
@@ -111,9 +111,9 @@ def validateExamples(examples, schemas, maxExamples, shuffle):
       print("Reached limit of " + str(maxExamples) + " examples to validate. Breaking.")
       break
       
-    if time.clock() - latestReportTime > 5:
+    if time.perf_counter() - latestReportTime > 5:
       print("Checked " + str(numChecked) + " / " + str(len(examples)) + " examples.", flush=True)
-      latestReportTime = time.clock()
+      latestReportTime = time.perf_counter()
       
   return failures, unchecked, numberOfSuccessfulValidations
 


### PR DESCRIPTION
### Applicable Issues
Fixes #250

### Description of the Change
time.clock() is deprecated and removed in Python 3.8. It was replaced by time.process_time() and time.perf_counter() in Python 3.3. Replace the calls in examples/validate.py with time.perf_counter(). This drops support for Python 2 so the shebang is adjusted (not that the shebang is very useful for this non-executable file).

This also fixes what probably was an unintentional buglet; on Linux time.clock() returned the elapsed CPU time but on Windows it returned the elapsed time. Since the number was seemingly used to report the validation progress every five seconds the behavior was only correct on Windows.

### Alternate Designs
We could've used time.time() given the low resolution requirement and the fact that we don't really care that that call returns a non-monotonous clock. That would've kept Python 2 compatibility, but Python 2 was EOLed almost a year ago so it's reasonable to drop support for it.

### Benefits
The script will work with Python 3.8.

### Possible Drawbacks
The script won't work with Python 2.x.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com\>
