### PR TITLE
Fix obvious typo in EiffelEnvironmentDefinedEvent docs

### DIFF
--- a/eiffel-vocabulary/EiffelEnvironmentDefinedEvent.md
+++ b/eiffel-vocabulary/EiffelEnvironmentDefinedEvent.md
@@ -29,7 +29,7 @@ __Description:__ The name of the environment.
 ### data.version
 __Type:__ String  
 __Required:__ No  
-__Description:__ The version of the environment, if any. This is in a sense redundant, as relationships between compositions can be tracked via the __PREVIOUS_VERSION__ link type, but can be used for improved clarity and semantics.
+__Description:__ The version of the environment, if any. This is in a sense redundant, as relationships between environments can be tracked via the __PREVIOUS_VERSION__ link type, but can be used for improved clarity and semantics.
 
 ### data.image
 __Type:__ String  


### PR DESCRIPTION
### Applicable Issues
N/A; trivial

### Description of the Change
The documentation of EiffelEnvironmentDefinedEvent's data.version member seems to have been copied from EiffelCompositionDefinedEvent without getting all references to "composition" replaced with "environment".

### Alternate Designs
None.

### Benefits
Less confusion.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com\>
