### PR TITLE
Add guidelines for naming link types

### DIFF
--- a/eiffel-syntax-and-usage/event-design-guidelines.md
+++ b/eiffel-syntax-and-usage/event-design-guidelines.md
@@ -33,7 +33,4 @@ The design of Eiffel events is governed by the following guidelines:
 * __Information model integrity over reader convenience:__ Eiffel events are not convenient to read – or to publish – as they require graph traversal in order to derive any meaningful information. Do not work around this by including convenience information (typically duplication). Such measures will never be completely satisfactory. Instead the primary concern of event design is information model integrity; readability and usability is the concern of services built upon that data source.
 * __Key names in camelCase:__ All key names shall use camelCase.
 * __Enumerations in CAPS_WITH_UNDERSCORE:__ All enumerated values shall use CAPS_WITH_UNDERSCORE.
-
-
-
-
+* __Link types are nouns:__ Link types shall have names that fit the pattern "\<target event> is the \<source event>'s \<link type>", implying that they are nouns that describe the relationship between the source and the target event.


### PR DESCRIPTION
### Applicable Issues
Fixes #231

### Description of the Change
This puts in writing what has been the de facto naming standard for all current event types, namely that they should be nouns and fit one of these patterns:

    <target> is the <source>'s <type>
    <target> is one of the <source>'s <type>s

### Alternate Designs
None. This design rule isn't really novel, it's just putting words to today's de facto standard.

### Benefits
This should make it easier to come up with good and consistent names of link types that we consider adding.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
