### PR TITLE
validate.py: Make missing schemas a fatal error

### DIFF
--- a/examples/validate.py
+++ b/examples/validate.py
@@ -119,7 +119,7 @@ def validateExamples(examples, schemas, maxExamples, shuffle):
 
 def report(unchecked,failures,badSchemaFiles,badExampleFiles,numberOfSuccessfulValidations):
   for path, type, id, o in unchecked:
-    print("WARNING: Missing schema for " + id + "(" + type + ") in " + path + ".", flush=True)
+    print("ERROR: Missing schema for " + id + "(" + type + ") in " + path + ".", flush=True)
 
   for badSchemaFile in badSchemaFiles:
     print("ERROR: Failed to load schema from file", badSchemaFile, flush=True)
@@ -156,7 +156,7 @@ def main(maxExamples, includeArchives, shuffle):
 
   report(unchecked, failures, badSchemaFiles, badExampleFiles, numberOfSuccessfulValidations)
 
-  if len(badSchemaFiles) > 0 or len(badExampleFiles) > 0 or len(failures) > 0:
+  if (len(badSchemaFiles) + len(badExampleFiles) + len(failures) + len(unchecked)) > 0:
     sys.exit("Validation failed.")
 
 def usage():


### PR DESCRIPTION
### Applicable Issues
Fixes #268

### Description of the Change
It doesn't make sense that missing schemas, e.g. caused by typos in the event version in the examples, only result in warnings and a zero exit code. Change this so that a missing schema is as bad as a failed validation.

### Alternate Designs
None.

### Benefits
Decreased risk of mistakes going unnoticed.

### Possible Drawbacks
None? I suppose we'd break any use case where missing schema files are normal, but I don't know what that use case would be.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and     have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution     are public and that a record of the contribution (including all     personal information I submit with it, including my sign-off) is     maintained indefinitely and may be redistributed consistent with     this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
