### PR TITLE
TERCC: Add UUID validation pattern to links.target

### DIFF
--- a/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md
+++ b/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md
@@ -276,6 +276,7 @@ __Description:__ The number of the event within the named sequence.
 ## Version History
 | Version   | Introduced in                                          | Changes                                 |
 | --------- | ------------------------------------------------------ | --------------------------------------- |
+| 4.1.1     | Current version                                        | Add missing validation pattern to links.target member (see [Issue 271](https://github.com/eiffel-community/eiffel/issues/271)). |
 | 4.1.0     | Current version                                        | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 4.0.0     | [edition-agen](../../../tree/edition-agen)             | Improved information integrity protection | (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)) |
 | 3.0.0     | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |

--- a/schemas/EiffelTestExecutionRecipeCollectionCreatedEvent/4.1.1.json
+++ b/schemas/EiffelTestExecutionRecipeCollectionCreatedEvent/4.1.1.json
@@ -1,0 +1,281 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [ "EiffelTestExecutionRecipeCollectionCreatedEvent" ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [ "4.1.1" ],
+          "default": "4.1.1"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "selectionStrategy": {
+          "type": "object",
+          "properties": {
+            "tracker": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "additionalProperties": false
+        },
+        "batchesUri": {
+          "type": "string"
+        },
+        "batches": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "priority": {
+                "type": "integer"
+              },
+              "recipes": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+                    },
+                    "testCase": {
+                      "type": "object",
+                      "properties": {
+                        "tracker": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "uri": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "constraints": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "value": {
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "value"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "testCase"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "dependencies": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "dependent": {
+                      "type": "string"
+                    },
+                    "dependency": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "dependent",
+                    "dependency"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "priority",
+              "recipes"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {
+              }
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "selectionStrategy"
+      ],
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
### Applicable Issues
Fixes #271 

### Description of the Change
The TERCC event's validation pattern for links.target disappeared in 2.0.0 of the event which no doubt must've been a mistake. Introduce 4.1.1 to fix this bug and align TERCC with all other event types.

Here's the diff between 4.1.0 and 4.1.1:

```
$ diff -u 4.1.0.json 4.1.1.json                             
--- 4.1.0.json	2021-09-20 14:37:09.475728017 +0200
+++ 4.1.1.json	2021-09-20 16:10:53.794895663 +0200
@@ -15,8 +15,8 @@
         },
         "version": {
           "type": "string",
-          "enum": [ "4.1.0" ],
-          "default": "4.1.0"
+          "enum": [ "4.1.1" ],
+          "default": "4.1.1"
         },
         "time": {
           "type": "integer"
@@ -257,7 +257,8 @@
             "type": "string"
           },
           "target": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
           },
           "domainId": {
             "type": "string"
```

### Alternate Designs
None.

### Benefits
TERCC enforces UUIDs for link targets just like all other events.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
