### PR TITLE
Glossary: Add midding TOC entry

### DIFF
--- a/eiffel-syntax-and-usage/glossary.md
+++ b/eiffel-syntax-and-usage/glossary.md
@@ -23,6 +23,7 @@ This a non-exhaustive, alphabetical list of terms used in the [Eiffel vocabulary
    - [Artifact](#artifact)
    - [Composition](#composition)
    - [Confidence Level](#confidence-level)
+   - [Domain](#domain)
    - [Environment](#environment)
    - [Event](#event)
    - [Link](#link)


### PR DESCRIPTION
### Applicable Issues
N/A; trivial

### Description of the Change
Commit f5f82c7 that added the glossary entry for "domain" mistakenly left out the corresponding entry in the table of contents.

### Alternate Designs
None.

### Benefits
Complete TOC.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
