### PR TITLE
Prepare for release of Lyon

### DIFF
--- a/eiffel-syntax-and-usage/versioning.md
+++ b/eiffel-syntax-and-usage/versioning.md
@@ -1,5 +1,5 @@
 <!---
-   Copyright 2017 Ericsson AB.
+   Copyright 2017-2021 Ericsson AB and others.
    For a full list of individual contributors, please see the commit history.
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,7 +27,7 @@ That being said, to facilitate compatibility and consistency, the Eiffel protoco
 | Edition   | Tag                                                 | Changes                                          |
 | --------- | --------------------------------------------------- | ------------------------------------------------ |
 | Arica  | _Reserved for future use._  | |
-| Lyon  | _Reserved for future use._  | |
+| Lyon  | [edition-lyon](../../../tree/edition-lyon)  | Added domainId member to links ([Issue 233](https://github.com/eiffel-community/eiffel/issues/233)), added {mediaType,tags} to data.{liveLogs,persistentLogs} of various event types ([Issue 166](https://github.com/eiffel-community/eiffel/issues/166)), added RUNTIME_ENVIRONMENT as link type for ED ([Issue 258](https://github.com/eiffel-community/eiffel/issues/258)), and added missing validation pattern for links.target of TERCC ([Issue 271](https://github.com/eiffel-community/eiffel/issues/271)). |
 | Paris  | [edition-paris](../../../tree/edition-paris)  | Minor backwards-compatible changes to CD and ArtP (Issues [218](https://github.com/eiffel-community/eiffel/issues/218) and [248](https://github.com/eiffel-community/eiffel/issues/248)). |
 | Agen-1  | [edition-agen-1](../../../tree/edition-agen-1)  | Maintenance release to solve [Issue 205](https://github.com/eiffel-community/eiffel/issues/205). |
 | Agen  | [edition-agen](../../../tree/edition-agen)  | Introduced [EiffelIssueDefinedEvent](../eiffel-vocabulary/EiffelIssueDefinedEvent.md). Updated meta.security of all event types. Changed from GAV to purl based artifact identification. Introduced automated packaging of schema files for edition tags. Added detailed rules and examples for event type version stepping. |

--- a/eiffel-vocabulary/EiffelActivityCanceledEvent.md
+++ b/eiffel-vocabulary/EiffelActivityCanceledEvent.md
@@ -179,7 +179,7 @@ __Description:__ The number of the event within the named sequence.
 ## Version History
 | Version   | Introduced in                                          | Changes                                 |
 | --------- | ------------------------------------------------------ | --------------------------------------- |
-| 3.1.0     | Current version                                        | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
+| 3.1.0     | [edition-lyon](../../../tree/edition-lyon)             | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.0.0     | [edition-agen](../../../tree/edition-agen)             | Improved information integrity protection | (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)) |
 | 2.0.0     | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelActivityCanceledEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0     | [edition-toulouse](../../../tree/edition-toulouse)     | Multiple links of type FLOW_CONTEXT allowed. |

--- a/eiffel-vocabulary/EiffelActivityFinishedEvent.md
+++ b/eiffel-vocabulary/EiffelActivityFinishedEvent.md
@@ -221,8 +221,8 @@ __Description:__ The number of the event within the named sequence.
 ## Version History
 | Version   | Introduced in                                          | Changes                                 |
 | --------- | ------------------------------------------------------ | --------------------------------------- |
-| 3.2.0     | Current version                                        | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
-| 3.1.0     | Current version                                        | Add `data.persistentLogs.{mediaType,tags}`.   |
+| 3.2.0     | [edition-lyon](../../../tree/edition-lyon)             | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
+| 3.1.0     | No edition set                                         | Add `data.persistentLogs.{mediaType,tags}`.   |
 | 3.0.0     | [edition-agen](../../../tree/edition-agen)             | Improved information integrity protection | (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)) |
 | 2.0.0     | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelActivityFinishedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0     | [edition-toulouse](../../../tree/edition-toulouse)     | Multiple links of type FLOW_CONTEXT allowed. |

--- a/eiffel-vocabulary/EiffelActivityStartedEvent.md
+++ b/eiffel-vocabulary/EiffelActivityStartedEvent.md
@@ -210,8 +210,8 @@ __Description:__ The number of the event within the named sequence.
 ## Version History
 | Version   | Introduced in                                          | Changes                                 |
 | --------- | ------------------------------------------------------ | --------------------------------------- |
-| 4.2.0     | Current version                                        | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
-| 4.1.0     | Current version                                        | Add `data.liveLogs.{mediaType,tags}`.   |
+| 4.2.0     | [edition-lyon](../../../tree/edition-lyon)             | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
+| 4.1.0     | No edition set                                         | Add `data.liveLogs.{mediaType,tags}`.   |
 | 4.0.0     | [edition-agen-1](../../../tree/edition-agen-1)             | Bug fix in schema file (see [Issue 205](https://github.com/eiffel-community/eiffel/issues/205)) |
 | 3.0.0     | [edition-agen](../../../tree/edition-agen)             | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)) |
 | 2.0.0     | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelActivityStartedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |

--- a/eiffel-vocabulary/EiffelActivityTriggeredEvent.md
+++ b/eiffel-vocabulary/EiffelActivityTriggeredEvent.md
@@ -207,7 +207,7 @@ __Description:__ The number of the event within the named sequence.
 ## Version History
 | Version   | Introduced in                                          | Changes                                 |
 | --------- | ------------------------------------------------------ | --------------------------------------- |
-| 4.1.0     | Current version                                        | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
+| 4.1.0     | [edition-lyon](../../../tree/edition-lyon)             | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 4.0.0     | [edition-agen-1](../../../tree/edition-agen-1)             | Bug fix in schema file (see [Issue 205](https://github.com/eiffel-community/eiffel/issues/205)) |
 | 3.0.0     | [edition-agen](../../../tree/edition-agen)             | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)) |
 | 2.0.0     | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelActivityTriggeredEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |

--- a/eiffel-vocabulary/EiffelAnnouncementPublishedEvent.md
+++ b/eiffel-vocabulary/EiffelAnnouncementPublishedEvent.md
@@ -195,7 +195,7 @@ __Description:__ The number of the event within the named sequence.
 ## Version History
 | Version   | Introduced in                                          | Changes                                 |
 | --------- | ------------------------------------------------------ | --------------------------------------- |
-| 3.1.0     | Current version                                        | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
+| 3.1.0     | [edition-lyon](../../../tree/edition-lyon)             | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.0.0     | [edition-agen](../../../tree/edition-agen)             | Improved information integrity protection | (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)) |
 | 2.0.0     | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelAnnouncementPublishedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0     | [edition-toulouse](../../../tree/edition-toulouse)     | Multiple links of type FLOW_CONTEXT allowed. |

--- a/eiffel-vocabulary/EiffelArtifactCreatedEvent.md
+++ b/eiffel-vocabulary/EiffelArtifactCreatedEvent.md
@@ -239,7 +239,7 @@ __Description:__ The number of the event within the named sequence.
 ## Version History
 | Version   | Introduced in                                          | Changes                                 |
 | --------- | ------------------------------------------------------ | --------------------------------------- |
-| 3.1.0     | Current version                                        | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
+| 3.1.0     | [edition-lyon](../../../tree/edition-lyon)             | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.0.0     | [edition-agen](../../../tree/edition-agen)             | Improved information integrity protection | (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)) |
 | 2.0.0     | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelArtifactCreatedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0     | [edition-toulouse](../../../tree/edition-toulouse)     | Multiple links of type FLOW_CONTEXT allowed. |

--- a/eiffel-vocabulary/EiffelArtifactPublishedEvent.md
+++ b/eiffel-vocabulary/EiffelArtifactPublishedEvent.md
@@ -199,7 +199,7 @@ __Description:__ The number of the event within the named sequence.
 ## Version History
 | Version   | Introduced in                                          | Changes                                 |
 | --------- | ------------------------------------------------------ | --------------------------------------- |
-| 3.2.0     | Current version                                        | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
+| 3.2.0     | [edition-lyon](../../../tree/edition-lyon)             | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.1.0     | [edition-paris](../../../tree/edition-paris)           | Added name qualifier for artifact locations (see [Issue 248](https://github.com/eiffel-community/eiffel/issues/248)) |
 | 3.0.0     | [edition-agen](../../../tree/edition-agen)             | Improved information integrity protection | (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)) |
 | 2.0.0     | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelArtifactPublishedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |

--- a/eiffel-vocabulary/EiffelArtifactReusedEvent.md
+++ b/eiffel-vocabulary/EiffelArtifactReusedEvent.md
@@ -183,7 +183,7 @@ __Description:__ The number of the event within the named sequence.
 ## Version History
 | Version   | Introduced in                                          | Changes                                 |
 | --------- | ------------------------------------------------------ | --------------------------------------- |
-| 3.1.0     | Current version                                        | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
+| 3.1.0     | [edition-lyon](../../../tree/edition-lyon)             | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.0.0     | [edition-agen](../../../tree/edition-agen)             | Improved information integrity protection | (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)) |
 | 2.0.0     | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelArtifactReusedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0     | [edition-toulouse](../../../tree/edition-toulouse)     | Multiple links of type FLOW_CONTEXT allowed. |

--- a/eiffel-vocabulary/EiffelCompositionDefinedEvent.md
+++ b/eiffel-vocabulary/EiffelCompositionDefinedEvent.md
@@ -192,7 +192,7 @@ __Description:__ The number of the event within the named sequence.
 ## Version History
 | Version   | Introduced in                                          | Changes                                 |
 | --------- | ------------------------------------------------------ | --------------------------------------- |
-| 3.2.0     | Current version                                        | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
+| 3.2.0     | [edition-lyon](../../../tree/edition-lyon)             | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.1.0     | [edition-paris](../../../tree/edition-paris)           | Added SCC as valid target for ELEMENT links (see [Issue 218](https://github.com/eiffel-community/eiffel/issues/218)) |
 | 3.0.0     | [edition-agen](../../../tree/edition-agen)             | Improved information integrity protection | (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)) |
 | 2.0.0     | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelCompositionDefinedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |

--- a/eiffel-vocabulary/EiffelConfidenceLevelModifiedEvent.md
+++ b/eiffel-vocabulary/EiffelConfidenceLevelModifiedEvent.md
@@ -225,7 +225,7 @@ __Description:__ The number of the event within the named sequence.
 ## Version History
 | Version   | Introduced in                                          | Changes                                 |
 | --------- | ------------------------------------------------------ | --------------------------------------- |
-| 3.1.0     | Current version                                        | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
+| 3.1.0     | [edition-lyon](../../../tree/edition-lyon)             | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.0.0     | [edition-agen](../../../tree/edition-agen)             | Improved information integrity protection | (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)) |
 | 2.0.0     | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelConfidenceLevelModifiedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0     | [edition-toulouse](../../../tree/edition-toulouse)     | Multiple links of type FLOW_CONTEXT allowed. |

--- a/eiffel-vocabulary/EiffelEnvironmentDefinedEvent.md
+++ b/eiffel-vocabulary/EiffelEnvironmentDefinedEvent.md
@@ -217,8 +217,8 @@ __Description:__ The number of the event within the named sequence.
 ## Version History
 | Version   | Introduced in                                          | Changes                                 |
 | --------- | ------------------------------------------------------ | --------------------------------------- |
-| 3.2.0     | Current version                                        | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
-| 3.1.0     | Current version                                        | Added RUNTIME_ENVIRONMENT link type. |
+| 3.2.0     | [edition-lyon](../../../tree/edition-lyon)             | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
+| 3.1.0     | No edition set                                         | Added RUNTIME_ENVIRONMENT link type. |
 | 3.0.0     | [edition-agen](../../../tree/edition-agen)             | Improved information integrity protection | (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)) |
 | 2.0.0     | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelEnvironmentDefinedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0     | [edition-toulouse](../../../tree/edition-toulouse)     | Multiple links of type FLOW_CONTEXT allowed. |

--- a/eiffel-vocabulary/EiffelFlowContextDefinedEvent.md
+++ b/eiffel-vocabulary/EiffelFlowContextDefinedEvent.md
@@ -195,7 +195,7 @@ __Description:__ The number of the event within the named sequence.
 ## Version History
 | Version   | Introduced in                                          | Changes                                 |
 | --------- | ------------------------------------------------------ | --------------------------------------- |
-| 3.1.0     | Current version                                        | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
+| 3.1.0     | [edition-lyon](../../../tree/edition-lyon)             | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.0.0     | [edition-agen](../../../tree/edition-agen)             | Improved information integrity protection | (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)) |
 | 2.0.0     | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelFlowContextDefinedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0     | [edition-toulouse](../../../tree/edition-toulouse)     | Multiple links of type FLOW_CONTEXT allowed. |

--- a/eiffel-vocabulary/EiffelIssueDefinedEvent.md
+++ b/eiffel-vocabulary/EiffelIssueDefinedEvent.md
@@ -230,7 +230,7 @@ __Description:__ The number of the event within the named sequence.
 ## Version History
 | Version   | Introduced in                                          | Changes                                 |
 | --------- | ------------------------------------------------------ | --------------------------------------- |
-| 3.1.0     | Current version                                        | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
+| 3.1.0     | [edition-lyon](../../../tree/edition-lyon)             | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.0.0     | [edition-agen](../../../tree/edition-agen)             | Improved information integrity protection | (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)) |
 | 2.0.0     | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelIssueDefinedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.0.0     | [0706840](../../../blob/070684053ceb1da5fb42d9f0ef21df816961d6bc/eiffel-vocabulary/EiffelIssueDefinedEvent.md) | Initial version                         |

--- a/eiffel-vocabulary/EiffelIssueVerifiedEvent.md
+++ b/eiffel-vocabulary/EiffelIssueVerifiedEvent.md
@@ -209,7 +209,7 @@ __Description:__ The number of the event within the named sequence.
 ## Version History
 | Version   | Introduced in                                          | Changes                                 |
 | --------- | ------------------------------------------------------ | --------------------------------------- |
-| 4.1.0     | Current version                                        | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
+| 4.1.0     | [edition-lyon](../../../tree/edition-lyon)             | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 4.0.0     | [edition-agen](../../../tree/edition-agen)             | Improved information integrity protection | (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)) |
 | 3.0.0     | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelIssueVerifiedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 2.0.0     | [0706840](../../../blob/070684053ceb1da5fb42d9f0ef21df816961d6bc/eiffel-vocabulary/EiffelIssueVerifiedEvent.md) | Replaced data.issues with links         |

--- a/eiffel-vocabulary/EiffelSourceChangeCreatedEvent.md
+++ b/eiffel-vocabulary/EiffelSourceChangeCreatedEvent.md
@@ -355,7 +355,7 @@ __Description:__ The number of the event within the named sequence.
 ## Version History
 | Version   | Introduced in                                          | Changes                                 |
 | --------- | ------------------------------------------------------ | --------------------------------------- |
-| 4.1.0     | Current version                                        | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
+| 4.1.0     | [edition-lyon](../../../tree/edition-lyon)             | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 4.0.0     | [edition-agen](../../../tree/edition-agen)             | Improved information integrity protection | (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)) |
 | 3.0.0     | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelSourceChangeCreatedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 2.0.0     | [0706840](../../../blob/070684053ceb1da5fb42d9f0ef21df816961d6bc/eiffel-vocabulary/EiffelSourceChangeCreatedEvent.md) | Replaced data.issues with links         |

--- a/eiffel-vocabulary/EiffelSourceChangeSubmittedEvent.md
+++ b/eiffel-vocabulary/EiffelSourceChangeSubmittedEvent.md
@@ -304,7 +304,7 @@ __Description:__ The number of the event within the named sequence.
 ## Version History
 | Version   | Introduced in                                          | Changes                                 |
 | --------- | ------------------------------------------------------ | --------------------------------------- |
-| 3.1.0     | Current version                                        | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
+| 3.1.0     | [edition-lyon](../../../tree/edition-lyon)             | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.0.0     | [edition-agen](../../../tree/edition-agen)             | Improved information integrity protection | (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)) |
 | 2.0.0     | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelSourceChangeCreatedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0     | [edition-toulouse](../../../tree/edition-toulouse)     | Multiple links of type FLOW_CONTEXT allowed. |

--- a/eiffel-vocabulary/EiffelTestCaseCanceledEvent.md
+++ b/eiffel-vocabulary/EiffelTestCaseCanceledEvent.md
@@ -180,7 +180,7 @@ __Description:__ The number of the event within the named sequence.
 ## Version History
 | Version   | Introduced in                                          | Changes                                 |
 | --------- | ------------------------------------------------------ | --------------------------------------- |
-| 3.1.0     | Current version                                        | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
+| 3.1.0     | [edition-lyon](../../../tree/edition-lyon)             | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.0.0     | [edition-agen](../../../tree/edition-agen)             | Improved information integrity protection | (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)) |
 | 2.0.0     | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestCaseCanceledEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0     | [edition-toulouse](../../../tree/edition-toulouse)     | Multiple links of type FLOW_CONTEXT allowed. |

--- a/eiffel-vocabulary/EiffelTestCaseFinishedEvent.md
+++ b/eiffel-vocabulary/EiffelTestCaseFinishedEvent.md
@@ -248,8 +248,8 @@ __Description:__ The number of the event within the named sequence.
 ## Version History
 | Version   | Introduced in                                          | Changes                                 |
 | --------- | ------------------------------------------------------ | --------------------------------------- |
-| 3.2.0     | Current version                                        | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
-| 3.1.0     | Current version                                        | Add `data.persistentLogs.{mediaType,tags}`.   |
+| 3.2.0     | [edition-lyon](../../../tree/edition-lyon)             | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
+| 3.1.0     | No edition set                                         | Add `data.persistentLogs.{mediaType,tags}`.   |
 | 3.0.0     | [edition-agen](../../../tree/edition-agen)             | Improved information integrity protection | (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)) |
 | 2.0.0     | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestCaseFinishedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0     | [edition-toulouse](../../../tree/edition-toulouse)     | Multiple links of type FLOW_CONTEXT allowed. |

--- a/eiffel-vocabulary/EiffelTestCaseStartedEvent.md
+++ b/eiffel-vocabulary/EiffelTestCaseStartedEvent.md
@@ -211,8 +211,8 @@ __Description:__ The number of the event within the named sequence.
 ## Version History
 | Version   | Introduced in                                          | Changes                                 |
 | --------- | ------------------------------------------------------ | --------------------------------------- |
-| 3.2.0     | Current version                                        | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
-| 3.1.0     | Current version                                        | Add `data.liveLogs.{mediaType,tags}`.   |
+| 3.2.0     | [edition-lyon](../../../tree/edition-lyon)             | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
+| 3.1.0     | No edition set                                         | Add `data.liveLogs.{mediaType,tags}`.   |
 | 3.0.0     | [edition-agen](../../../tree/edition-agen)             | Improved information integrity protection | (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)) |
 | 2.0.0     | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestCaseStartedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0     | [edition-toulouse](../../../tree/edition-toulouse)     | Multiple links of type FLOW_CONTEXT allowed. |

--- a/eiffel-vocabulary/EiffelTestCaseTriggeredEvent.md
+++ b/eiffel-vocabulary/EiffelTestCaseTriggeredEvent.md
@@ -249,7 +249,7 @@ __Description:__ The number of the event within the named sequence.
 ## Version History
 | Version   | Introduced in                                          | Changes                                 |
 | --------- | ------------------------------------------------------ | --------------------------------------- |
-| 3.1.0     | Current version                                        | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
+| 3.1.0     | [edition-lyon](../../../tree/edition-lyon)             | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.0.0     | [edition-agen](../../../tree/edition-agen)             | Improved information integrity protection | (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)) |
 | 2.0.0     | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestCaseTriggeredEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0     | [edition-toulouse](../../../tree/edition-toulouse)     | Multiple links of type FLOW_CONTEXT allowed. |

--- a/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md
+++ b/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md
@@ -276,8 +276,8 @@ __Description:__ The number of the event within the named sequence.
 ## Version History
 | Version   | Introduced in                                          | Changes                                 |
 | --------- | ------------------------------------------------------ | --------------------------------------- |
-| 4.1.1     | Current version                                        | Add missing validation pattern to links.target member (see [Issue 271](https://github.com/eiffel-community/eiffel/issues/271)). |
-| 4.1.0     | Current version                                        | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
+| 4.1.1     | [edition-lyon](../../../tree/edition-lyon)             | Add missing validation pattern to links.target member (see [Issue 271](https://github.com/eiffel-community/eiffel/issues/271)). |
+| 4.1.0     | No edition set                                         | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 4.0.0     | [edition-agen](../../../tree/edition-agen)             | Improved information integrity protection | (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)) |
 | 3.0.0     | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 2.1.0     | [edition-toulouse](../../../tree/edition-toulouse)     | Multiple links of type FLOW_CONTEXT allowed. |

--- a/eiffel-vocabulary/EiffelTestSuiteFinishedEvent.md
+++ b/eiffel-vocabulary/EiffelTestSuiteFinishedEvent.md
@@ -231,8 +231,8 @@ __Description:__ The number of the event within the named sequence.
 ## Version History
 | Version   | Introduced in                                          | Changes                                 |
 | --------- | ------------------------------------------------------ | --------------------------------------- |
-| 3.2.0     | Current version                                        | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
-| 3.1.0     | Current version                                        | Add `data.persistentLogs.{mediaType,tags}`.   |
+| 3.2.0     | [edition-lyon](../../../tree/edition-lyon)             | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
+| 3.1.0     | No edition set                                         | Add `data.persistentLogs.{mediaType,tags}`.   |
 | 3.0.0     | [edition-agen](../../../tree/edition-agen)             | Improved information integrity protection | (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)) |
 | 2.0.0     | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestSuiteFinishedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0     | [edition-toulouse](../../../tree/edition-toulouse)     | Multiple links of type FLOW_CONTEXT allowed. |

--- a/eiffel-vocabulary/EiffelTestSuiteStartedEvent.md
+++ b/eiffel-vocabulary/EiffelTestSuiteStartedEvent.md
@@ -217,8 +217,8 @@ __Description:__ The number of the event within the named sequence.
 ## Version History
 | Version   | Introduced in                                          | Changes                                 |
 | --------- | ------------------------------------------------------ | --------------------------------------- |
-| 3.2.0     | Current version                                        | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
-| 3.1.0     | Current version                                        | Add `data.liveLogs.{mediaType,tags}`.   |
+| 3.2.0     | [edition-lyon](../../../tree/edition-lyon)             | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
+| 3.1.0     | No edition set                                         | Add `data.liveLogs.{mediaType,tags}`.   |
 | 3.0.0     | [edition-agen](../../../tree/edition-agen)             | Improved information integrity protection | (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)) |
 | 2.0.0     | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestSuiteStartedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0     | [edition-toulouse](../../../tree/edition-toulouse)     | Multiple links of type FLOW_CONTEXT allowed. |


### PR DESCRIPTION
### Applicable Issues
Fixes #272

### Description of the Change
Like what was done for the release of the Paris edition (commit d8fd110066f6e4f62a711ef40ee2f34ba8cdf026) we do two things in preparation of the release of the Lyon edition:

* Replace all "Current version" references in the Version History tables in the eiffel-vocabulary files with a reference to the (not yet existing) edition-lyon tag.
* Claim the Lyon edition in the table in versioning.md.

### Alternate Designs
None.

### Benefits
Makes new protocol versions widely available.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
