### PR TITLE
Remove empty meta.source from ArtC example event

### DIFF
--- a/examples/events/EiffelArtifactCreatedEvent/backend.json
+++ b/examples/events/EiffelArtifactCreatedEvent/backend.json
@@ -3,8 +3,6 @@
     "type": "EiffelArtifactCreatedEvent",
     "version": "3.0.0",
     "time": 1234567890,
-    "source": {
-    },
     "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },
   "data": {


### PR DESCRIPTION
### Applicable Issues
Fixes #283 

### Description of the Change
The backend.json examples for ArtC contained an empty meta.source member. While technically okay it's uncalled for and can be confusing for readers. It can also cause problems for tests of code that use these examples as testdata. See the associated issue for an elaboration.

### Alternate Designs
None.

### Benefits
Less confusion, less hassle for those using these examples for testing serialization code.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com\>
