### PR TITLE
Run Black, flake8, and isort via tox.ini

### DIFF
--- a/examples/reference-data-sets/default/generator.py
+++ b/examples/reference-data-sets/default/generator.py
@@ -22,622 +22,1102 @@ import getopt
 import sys
 import random
 
+
 def generateGenericMeta(type, t, v):
-  return {"type": type, "id": str(uuid.uuid4()), "time": t, "source": {"domainId": "example.domain"}, "version": v}
+    return {
+        "type": type,
+        "id": str(uuid.uuid4()),
+        "time": t,
+        "source": {"domainId": "example.domain"},
+        "version": v,
+    }
+
 
 def link(source, target, type):
-  if not target:
-    return
+    if not target:
+        return
 
-  source["links"].append({"type": type, "target": target["meta"]["id"]})
+    source["links"].append({"type": type, "target": target["meta"]["id"]})
+
 
 def generateGenericMessage(type, t, v, name, iteration):
-  meta = generateGenericMeta(type, t, v)
-  data = {"customData": [{"key": "name", "value": name}, {"key": "iteration", "value": iteration}]}
-  links = []
-  msg = {}
-  msg["meta"] = meta
-  msg["data"] = data
-  msg["links"] = links
-  return msg
+    meta = generateGenericMeta(type, t, v)
+    data = {
+        "customData": [
+            {"key": "name", "value": name},
+            {"key": "iteration", "value": iteration},
+        ]
+    }
+    links = []
+    msg = {}
+    msg["meta"] = meta
+    msg["data"] = data
+    msg["links"] = links
+    return msg
+
 
 def findLatestPrevious(iterationsMap, currentIteration, name):
-  for it in range(currentIteration - 1, -1, -1):
-    if it in iterationsMap:
-      if name in iterationsMap[it]:
-        return iterationsMap[it][name]
+    for it in range(currentIteration - 1, -1, -1):
+        if it in iterationsMap:
+            if name in iterationsMap[it]:
+                return iterationsMap[it][name]
+
 
 def randomizeVerdict(chanceOfSuccess):
-  if random.random() < chanceOfSuccess:
-    return "PASSED"
-  else:
-    return "FAILED"
+    if random.random() < chanceOfSuccess:
+        return "PASSED"
+    else:
+        return "FAILED"
 
-def getOutcomeValuesFromVerdicts(testCaseFinishedEventsArray, positiveName, negativeName):
-  for tcfEvent in testCaseFinishedEventsArray:
-    if tcfEvent["data"]["outcome"]["verdict"] != "PASSED":
-      return negativeName
 
-  return positiveName
+def getOutcomeValuesFromVerdicts(
+    testCaseFinishedEventsArray, positiveName, negativeName
+):
+    for tcfEvent in testCaseFinishedEventsArray:
+        if tcfEvent["data"]["outcome"]["verdict"] != "PASSED":
+            return negativeName
+
+    return positiveName
+
 
 def generateSCC1(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelSourceChangeCreatedEvent", t, "1.0.0", "SCC1", iteration)
-  link(msg, findLatestPrevious(iterationsMap, iteration, "SCS1"), "BASE")
+    msg = generateGenericMessage(
+        "EiffelSourceChangeCreatedEvent", t, "1.0.0", "SCC1", iteration
+    )
+    link(msg, findLatestPrevious(iterationsMap, iteration, "SCS1"), "BASE")
 
-  msg["data"]["gitIdentifier"] = {"commitId": "fd090b60a4aedc5161da9c035a49b14a319829c5", "branch": "topic-branch-" + str(iteration), "repoName": "myRepo", "repoUri": "https://repo.com"}
-  msg["data"]["author"] = {"name": "John Doe", "email": "john.doe@company.com", "id": "johnxxx", "group": "Team Gophers"}
-  msg["data"]["change"] = {"files": "https://filelist.com/" + str(iteration), "insertions": random.randint(10, 500), "deletions": random.randint(10, 500)}
+    msg["data"]["gitIdentifier"] = {
+        "commitId": "fd090b60a4aedc5161da9c035a49b14a319829c5",
+        "branch": "topic-branch-" + str(iteration),
+        "repoName": "myRepo",
+        "repoUri": "https://repo.com",
+    }
+    msg["data"]["author"] = {
+        "name": "John Doe",
+        "email": "john.doe@company.com",
+        "id": "johnxxx",
+        "group": "Team Gophers",
+    }
+    msg["data"]["change"] = {
+        "files": "https://filelist.com/" + str(iteration),
+        "insertions": random.randint(10, 500),
+        "deletions": random.randint(10, 500),
+    }
 
-  return msg
+    return msg
+
 
 def generateSCS1(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelSourceChangeSubmittedEvent", t, "1.0.0", "SCS1", iteration)
-  link(msg, findLatestPrevious(iterationsMap, iteration, "SCS1"), "PREVIOUS_VERSION")
-  if "SCC1" in iterationsMap[iteration]:
-    link(msg, iterationsMap[iteration]["SCC1"], "CHANGE")
+    msg = generateGenericMessage(
+        "EiffelSourceChangeSubmittedEvent", t, "1.0.0", "SCS1", iteration
+    )
+    link(
+        msg,
+        findLatestPrevious(iterationsMap, iteration, "SCS1"),
+        "PREVIOUS_VERSION",
+    )
+    if "SCC1" in iterationsMap[iteration]:
+        link(msg, iterationsMap[iteration]["SCC1"], "CHANGE")
 
-  msg["data"]["gitIdentifier"] = {"commitId": "fd090b60a4aedc5161da9c035a49b14a319829b4", "branch": "master", "repoName": "myRepo", "repoUri": "https://repo.com"}
-  msg["data"]["submitter"] = {"name": "John Doe", "email": "john.doe@company.com", "id": "johnxxx", "group": "Team Gophers"}
+    msg["data"]["gitIdentifier"] = {
+        "commitId": "fd090b60a4aedc5161da9c035a49b14a319829b4",
+        "branch": "master",
+        "repoName": "myRepo",
+        "repoUri": "https://repo.com",
+    }
+    msg["data"]["submitter"] = {
+        "name": "John Doe",
+        "email": "john.doe@company.com",
+        "id": "johnxxx",
+        "group": "Team Gophers",
+    }
 
-  return msg
+    return msg
+
 
 def generateEDef1(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelEnvironmentDefinedEvent", t, "1.0.0", "EDef1", iteration)
-  msg["data"]["name"] = "Environment 1"
-  msg["data"]["version"] = str(iteration)
-  return msg
+    msg = generateGenericMessage(
+        "EiffelEnvironmentDefinedEvent", t, "1.0.0", "EDef1", iteration
+    )
+    msg["data"]["name"] = "Environment 1"
+    msg["data"]["version"] = str(iteration)
+    return msg
+
 
 def generateEDef2(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelEnvironmentDefinedEvent", t, "1.0.0", "EDef2", iteration)
-  msg["data"]["name"] = "Environment 2"
-  msg["data"]["version"] = str(iteration)
-  return msg
+    msg = generateGenericMessage(
+        "EiffelEnvironmentDefinedEvent", t, "1.0.0", "EDef2", iteration
+    )
+    msg["data"]["name"] = "Environment 2"
+    msg["data"]["version"] = str(iteration)
+    return msg
+
 
 def generateArtC3(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelArtifactCreatedEvent", t, "2.0.0", "ArtC3", iteration)
-  msg["data"]["identity"] = "pkg:maven/com.othercompany.library/third-party-library@3.2.4"
-  return msg
+    msg = generateGenericMessage(
+        "EiffelArtifactCreatedEvent", t, "2.0.0", "ArtC3", iteration
+    )
+    msg["data"][
+        "identity"
+    ] = "pkg:maven/com.othercompany.library/third-party-library@3.2.4"
+    return msg
+
 
 def generateCDef1(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelCompositionDefinedEvent", t, "1.0.0", "CDef1", iteration)
-  msg["data"]["name"] = "Composition 1"
-  msg["data"]["version"] = str(iteration)
-  link(msg, findLatestPrevious(iterationsMap, iteration, "CDef1"), "PREVIOUS_VERSION")
-  link(msg, iterationsMap[iteration]["CLM2"], "CAUSE")
-  link(msg, iterationsMap[iteration]["ArtC2"], "ELEMENT")
-  link(msg, iterationsMap[0]["ArtC3"], "ELEMENT")
-  return msg
+    msg = generateGenericMessage(
+        "EiffelCompositionDefinedEvent", t, "1.0.0", "CDef1", iteration
+    )
+    msg["data"]["name"] = "Composition 1"
+    msg["data"]["version"] = str(iteration)
+    link(
+        msg,
+        findLatestPrevious(iterationsMap, iteration, "CDef1"),
+        "PREVIOUS_VERSION",
+    )
+    link(msg, iterationsMap[iteration]["CLM2"], "CAUSE")
+    link(msg, iterationsMap[iteration]["ArtC2"], "ELEMENT")
+    link(msg, iterationsMap[0]["ArtC3"], "ELEMENT")
+    return msg
+
 
 def generateCDef2(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelCompositionDefinedEvent", t, "1.0.0", "CDef2", iteration)
-  msg["data"]["name"] = "Composition 2"
-  msg["data"]["version"] = str(iteration)
-  link(msg, findLatestPrevious(iterationsMap, iteration, "CDef2"), "PREVIOUS_VERSION")
-  link(msg, iterationsMap[iteration]["ActT4"], "CONTEXT")
-  link(msg, findLatestPrevious(iterationsMap, iteration + 1, "ArtCC1"), "ELEMENT")
-  link(msg, findLatestPrevious(iterationsMap, iteration + 1, "ArtCC2"), "ELEMENT")
-  link(msg, findLatestPrevious(iterationsMap, iteration + 1, "ArtCC3"), "ELEMENT")
-  return msg
+    msg = generateGenericMessage(
+        "EiffelCompositionDefinedEvent", t, "1.0.0", "CDef2", iteration
+    )
+    msg["data"]["name"] = "Composition 2"
+    msg["data"]["version"] = str(iteration)
+    link(
+        msg,
+        findLatestPrevious(iterationsMap, iteration, "CDef2"),
+        "PREVIOUS_VERSION",
+    )
+    link(msg, iterationsMap[iteration]["ActT4"], "CONTEXT")
+    link(
+        msg,
+        findLatestPrevious(iterationsMap, iteration + 1, "ArtCC1"),
+        "ELEMENT",
+    )
+    link(
+        msg,
+        findLatestPrevious(iterationsMap, iteration + 1, "ArtCC2"),
+        "ELEMENT",
+    )
+    link(
+        msg,
+        findLatestPrevious(iterationsMap, iteration + 1, "ArtCC3"),
+        "ELEMENT",
+    )
+    return msg
+
 
 def generateCDef3(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelCompositionDefinedEvent", t, "1.0.0", "CDef3", iteration)
-  msg["data"]["name"] = "Composition 3"
-  msg["data"]["version"] = str(iteration)
-  link(msg, findLatestPrevious(iterationsMap, iteration, "CDef3"), "PREVIOUS_VERSION")
-  link(msg, iterationsMap[iteration]["SCS1"], "ELEMENT")
-  return msg
+    msg = generateGenericMessage(
+        "EiffelCompositionDefinedEvent", t, "1.0.0", "CDef3", iteration
+    )
+    msg["data"]["name"] = "Composition 3"
+    msg["data"]["version"] = str(iteration)
+    link(
+        msg,
+        findLatestPrevious(iterationsMap, iteration, "CDef3"),
+        "PREVIOUS_VERSION",
+    )
+    link(msg, iterationsMap[iteration]["SCS1"], "ELEMENT")
+    return msg
+
 
 def generateArtC1(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelArtifactCreatedEvent", t, "2.0.0", "ArtC1", iteration)
-  link(msg, iterationsMap[iteration]["CDef1"], "COMPOSITION")
-  link(msg, iterationsMap[0]["EDef1"], "ENVIRONMENT")
-  link(msg, iterationsMap[iteration]["CDef1"], "CAUSE")
-  link(msg, findLatestPrevious(iterationsMap, iteration, "ArtC1"), "PREVIOUS_VERSION")
-  msg["data"]["identity"] = "pkg:maven/com.mycompany.myproduct/complete-system@1." + str(iteration) + ".0"
-  return msg
+    msg = generateGenericMessage(
+        "EiffelArtifactCreatedEvent", t, "2.0.0", "ArtC1", iteration
+    )
+    link(msg, iterationsMap[iteration]["CDef1"], "COMPOSITION")
+    link(msg, iterationsMap[0]["EDef1"], "ENVIRONMENT")
+    link(msg, iterationsMap[iteration]["CDef1"], "CAUSE")
+    link(
+        msg,
+        findLatestPrevious(iterationsMap, iteration, "ArtC1"),
+        "PREVIOUS_VERSION",
+    )
+    msg["data"]["identity"] = (
+        "pkg:maven/com.mycompany.myproduct/complete-system@1."
+        + str(iteration)
+        + ".0"
+    )
+    return msg
+
 
 def generateArtC2(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelArtifactCreatedEvent", t, "2.0.0", "ArtC2", iteration)
-  link(msg, iterationsMap[iteration]["CDef2"], "COMPOSITION")
-  link(msg, iterationsMap[0]["EDef2"], "ENVIRONMENT")
-  link(msg, findLatestPrevious(iterationsMap, iteration, "ArtC2"), "PREVIOUS_VERSION")
-  link(msg, iterationsMap[iteration]["ActT4"], "CONTEXT")
-  msg["data"]["identity"] = "pkg:maven/com.mycompany.myproduct/sub-system@1." + str(iteration) + ".0"
-  return msg
+    msg = generateGenericMessage(
+        "EiffelArtifactCreatedEvent", t, "2.0.0", "ArtC2", iteration
+    )
+    link(msg, iterationsMap[iteration]["CDef2"], "COMPOSITION")
+    link(msg, iterationsMap[0]["EDef2"], "ENVIRONMENT")
+    link(
+        msg,
+        findLatestPrevious(iterationsMap, iteration, "ArtC2"),
+        "PREVIOUS_VERSION",
+    )
+    link(msg, iterationsMap[iteration]["ActT4"], "CONTEXT")
+    msg["data"]["identity"] = (
+        "pkg:maven/com.mycompany.myproduct/sub-system@1."
+        + str(iteration)
+        + ".0"
+    )
+    return msg
+
 
 def generateArtCC1(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelArtifactCreatedEvent", t, "2.0.0", "ArtCC1", iteration)
-  link(msg, iterationsMap[iteration]["CDef3"], "COMPOSITION")
-  link(msg, iterationsMap[iteration]["CDef3"], "CAUSE")
-  link(msg, findLatestPrevious(iterationsMap, iteration, "ArtCC1"), "PREVIOUS_VERSION")
-  msg["data"]["identity"] = "pkg:maven/com.mycompany.myproduct/component-1@1." + str(iteration) + ".0"
-  return msg
+    msg = generateGenericMessage(
+        "EiffelArtifactCreatedEvent", t, "2.0.0", "ArtCC1", iteration
+    )
+    link(msg, iterationsMap[iteration]["CDef3"], "COMPOSITION")
+    link(msg, iterationsMap[iteration]["CDef3"], "CAUSE")
+    link(
+        msg,
+        findLatestPrevious(iterationsMap, iteration, "ArtCC1"),
+        "PREVIOUS_VERSION",
+    )
+    msg["data"]["identity"] = (
+        "pkg:maven/com.mycompany.myproduct/component-1@1."
+        + str(iteration)
+        + ".0"
+    )
+    return msg
+
 
 def generateArtCC2(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelArtifactCreatedEvent", t, "2.0.0", "ArtCC2", iteration)
-  link(msg, iterationsMap[iteration]["CDef3"], "COMPOSITION")
-  link(msg, iterationsMap[iteration]["CDef3"], "CAUSE")
-  link(msg, findLatestPrevious(iterationsMap, iteration, "ArtCC2"), "PREVIOUS_VERSION")
-  msg["data"]["identity"] = "pkg:maven/com.mycompany.myproduct/component-2@1." + str(iteration) + ".0"
-  return msg
+    msg = generateGenericMessage(
+        "EiffelArtifactCreatedEvent", t, "2.0.0", "ArtCC2", iteration
+    )
+    link(msg, iterationsMap[iteration]["CDef3"], "COMPOSITION")
+    link(msg, iterationsMap[iteration]["CDef3"], "CAUSE")
+    link(
+        msg,
+        findLatestPrevious(iterationsMap, iteration, "ArtCC2"),
+        "PREVIOUS_VERSION",
+    )
+    msg["data"]["identity"] = (
+        "pkg:maven/com.mycompany.myproduct/component-2@1."
+        + str(iteration)
+        + ".0"
+    )
+    return msg
+
 
 def generateArtCC3(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelArtifactCreatedEvent", t, "2.0.0", "ArtCC3", iteration)
-  link(msg, iterationsMap[iteration]["CDef3"], "COMPOSITION")
-  link(msg, iterationsMap[iteration]["CDef3"], "CAUSE")
-  link(msg, findLatestPrevious(iterationsMap, iteration, "ArtCC3"), "PREVIOUS_VERSION")
-  msg["data"]["identity"] = "pkg:maven/com.mycompany.myproduct/component-3@1." + str(iteration) + ".0"
-  return msg
+    msg = generateGenericMessage(
+        "EiffelArtifactCreatedEvent", t, "2.0.0", "ArtCC3", iteration
+    )
+    link(msg, iterationsMap[iteration]["CDef3"], "COMPOSITION")
+    link(msg, iterationsMap[iteration]["CDef3"], "CAUSE")
+    link(
+        msg,
+        findLatestPrevious(iterationsMap, iteration, "ArtCC3"),
+        "PREVIOUS_VERSION",
+    )
+    msg["data"]["identity"] = (
+        "pkg:maven/com.mycompany.myproduct/component-3@1."
+        + str(iteration)
+        + ".0"
+    )
+    return msg
+
 
 def generateArtP1(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelArtifactPublishedEvent", t, "1.0.0", "ArtP1", iteration)
-  link(msg, iterationsMap[iteration]["ArtC1"], "ARTIFACT")
-  link(msg, iterationsMap[iteration]["ArtC1"], "CAUSE")
-  msg["data"]["locations"] =  [{"type": "PLAIN", "uri": "https://myrepository.com/myCompleteSystemArtifact"}]
-  return msg
+    msg = generateGenericMessage(
+        "EiffelArtifactPublishedEvent", t, "1.0.0", "ArtP1", iteration
+    )
+    link(msg, iterationsMap[iteration]["ArtC1"], "ARTIFACT")
+    link(msg, iterationsMap[iteration]["ArtC1"], "CAUSE")
+    msg["data"]["locations"] = [
+        {
+            "type": "PLAIN",
+            "uri": "https://myrepository.com/myCompleteSystemArtifact",
+        }
+    ]
+    return msg
+
 
 def generateArtP2(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelArtifactPublishedEvent", t, "1.0.0", "ArtP2", iteration)
-  link(msg, iterationsMap[iteration]["ArtC2"], "ARTIFACT")
-  link(msg, iterationsMap[iteration]["ActT4"], "CONTEXT")
-  msg["data"]["locations"] =  [{"type": "PLAIN", "uri": "https://myrepository.com/mySubSystemArtifact"}]
-  return msg
+    msg = generateGenericMessage(
+        "EiffelArtifactPublishedEvent", t, "1.0.0", "ArtP2", iteration
+    )
+    link(msg, iterationsMap[iteration]["ArtC2"], "ARTIFACT")
+    link(msg, iterationsMap[iteration]["ActT4"], "CONTEXT")
+    msg["data"]["locations"] = [
+        {
+            "type": "PLAIN",
+            "uri": "https://myrepository.com/mySubSystemArtifact",
+        }
+    ]
+    return msg
+
 
 def generateActT3(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelActivityTriggeredEvent", t, "1.0.0", "ActT3", iteration)
-  link(msg, iterationsMap[iteration]["ArtP2"], "CAUSE")
-  msg["data"]["name"] = "Act3"
-  msg["data"]["categories"] = ["Sub-system Test Activity"]
-  msg["data"]["triggers"] = [ {"type": "EIFFEL_EVENT"} ]
-  msg["data"]["executionType"] = "AUTOMATED"
-  return msg
+    msg = generateGenericMessage(
+        "EiffelActivityTriggeredEvent", t, "1.0.0", "ActT3", iteration
+    )
+    link(msg, iterationsMap[iteration]["ArtP2"], "CAUSE")
+    msg["data"]["name"] = "Act3"
+    msg["data"]["categories"] = ["Sub-system Test Activity"]
+    msg["data"]["triggers"] = [{"type": "EIFFEL_EVENT"}]
+    msg["data"]["executionType"] = "AUTOMATED"
+    return msg
+
 
 def generateActS3(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelActivityStartedEvent", t, "1.0.0", "ActS3", iteration)
-  link(msg, iterationsMap[iteration]["ActT3"], "ACTIVITY_EXECUTION")
-  return msg
+    msg = generateGenericMessage(
+        "EiffelActivityStartedEvent", t, "1.0.0", "ActS3", iteration
+    )
+    link(msg, iterationsMap[iteration]["ActT3"], "ACTIVITY_EXECUTION")
+    return msg
+
 
 def generateActF3(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelActivityFinishedEvent", t, "1.0.0", "ActF3", iteration)
-  link(msg, iterationsMap[iteration]["ActT3"], "ACTIVITY_EXECUTION")
-  msg["data"]["outcome"] = {"conclusion": getOutcomeValuesFromVerdicts([iterationsMap[iteration]["TSF1"]], "SUCCESSFUL", "UNSUCCESSFUL")}
+    msg = generateGenericMessage(
+        "EiffelActivityFinishedEvent", t, "1.0.0", "ActF3", iteration
+    )
+    link(msg, iterationsMap[iteration]["ActT3"], "ACTIVITY_EXECUTION")
+    msg["data"]["outcome"] = {
+        "conclusion": getOutcomeValuesFromVerdicts(
+            [iterationsMap[iteration]["TSF1"]], "SUCCESSFUL", "UNSUCCESSFUL"
+        )
+    }
 
-  return msg
+    return msg
+
 
 def generateActT4(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelActivityTriggeredEvent", t, "1.0.0", "ActT4", iteration)
-  if "ArtCC1" in iterationsMap[iteration]:
-    link(msg,  iterationsMap[iteration]["ArtCC1"], "CAUSE")
-  if "ArtCC2" in iterationsMap[iteration]:
-    link(msg,  iterationsMap[iteration]["ArtCC2"], "CAUSE")
-  if "ArtCC3" in iterationsMap[iteration]:
-    link(msg,  iterationsMap[iteration]["ArtCC3"], "CAUSE")
-  msg["data"]["name"] = "Act4"
-  msg["data"]["categories"] = ["Sub-system Build Activity"]
-  msg["data"]["triggers"] = [ {"type": "EIFFEL_EVENT"} ]
-  msg["data"]["executionType"] = "AUTOMATED"
-  return msg
+    msg = generateGenericMessage(
+        "EiffelActivityTriggeredEvent", t, "1.0.0", "ActT4", iteration
+    )
+    if "ArtCC1" in iterationsMap[iteration]:
+        link(msg, iterationsMap[iteration]["ArtCC1"], "CAUSE")
+    if "ArtCC2" in iterationsMap[iteration]:
+        link(msg, iterationsMap[iteration]["ArtCC2"], "CAUSE")
+    if "ArtCC3" in iterationsMap[iteration]:
+        link(msg, iterationsMap[iteration]["ArtCC3"], "CAUSE")
+    msg["data"]["name"] = "Act4"
+    msg["data"]["categories"] = ["Sub-system Build Activity"]
+    msg["data"]["triggers"] = [{"type": "EIFFEL_EVENT"}]
+    msg["data"]["executionType"] = "AUTOMATED"
+    return msg
+
 
 def generateActS4(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelActivityStartedEvent", t, "1.0.0", "ActS4", iteration)
-  link(msg, iterationsMap[iteration]["ActT4"], "ACTIVITY_EXECUTION")
-  return msg
+    msg = generateGenericMessage(
+        "EiffelActivityStartedEvent", t, "1.0.0", "ActS4", iteration
+    )
+    link(msg, iterationsMap[iteration]["ActT4"], "ACTIVITY_EXECUTION")
+    return msg
+
 
 def generateActF4(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelActivityFinishedEvent", t, "1.0.0", "ActF4", iteration)
-  link(msg, iterationsMap[iteration]["ActT4"], "ACTIVITY_EXECUTION")
-  if "ArtC2" in iterationsMap[iteration]:
-    msg["data"]["outcome"] = {"conclusion": "SUCCESSFUL"}
-  else:
-    msg["data"]["outcome"] = {"conclusion": "UNSUCCESSFUL"}
+    msg = generateGenericMessage(
+        "EiffelActivityFinishedEvent", t, "1.0.0", "ActF4", iteration
+    )
+    link(msg, iterationsMap[iteration]["ActT4"], "ACTIVITY_EXECUTION")
+    if "ArtC2" in iterationsMap[iteration]:
+        msg["data"]["outcome"] = {"conclusion": "SUCCESSFUL"}
+    else:
+        msg["data"]["outcome"] = {"conclusion": "UNSUCCESSFUL"}
 
-  return msg
+    return msg
+
 
 def generateActT1(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelActivityTriggeredEvent", t, "1.0.0", "ActT1", iteration)
-  link(msg, iterationsMap[iteration]["ArtP1"], "CAUSE")
-  msg["data"]["name"] = "Act1"
-  msg["data"]["categories"] = ["Test Activity"]
-  msg["data"]["triggers"] = [ {"type": "EIFFEL_EVENT"} ]
-  msg["data"]["executionType"] = "AUTOMATED"
-  return msg
+    msg = generateGenericMessage(
+        "EiffelActivityTriggeredEvent", t, "1.0.0", "ActT1", iteration
+    )
+    link(msg, iterationsMap[iteration]["ArtP1"], "CAUSE")
+    msg["data"]["name"] = "Act1"
+    msg["data"]["categories"] = ["Test Activity"]
+    msg["data"]["triggers"] = [{"type": "EIFFEL_EVENT"}]
+    msg["data"]["executionType"] = "AUTOMATED"
+    return msg
+
 
 def generateActS1(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelActivityStartedEvent", t, "1.0.0", "ActS1", iteration)
-  link(msg, iterationsMap[iteration]["ActT1"], "ACTIVITY_EXECUTION")
-  return msg
+    msg = generateGenericMessage(
+        "EiffelActivityStartedEvent", t, "1.0.0", "ActS1", iteration
+    )
+    link(msg, iterationsMap[iteration]["ActT1"], "ACTIVITY_EXECUTION")
+    return msg
+
 
 def generateActF1(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelActivityFinishedEvent", t, "1.0.0", "ActF1", iteration)
-  link(msg, iterationsMap[iteration]["ActT1"], "ACTIVITY_EXECUTION")
-  msg["data"]["outcome"] = {"conclusion": getOutcomeValuesFromVerdicts([iterationsMap[iteration]["TCF1"], iterationsMap[iteration]["TCF2"]], "SUCCESSFUL", "UNSUCCESSFUL")}
+    msg = generateGenericMessage(
+        "EiffelActivityFinishedEvent", t, "1.0.0", "ActF1", iteration
+    )
+    link(msg, iterationsMap[iteration]["ActT1"], "ACTIVITY_EXECUTION")
+    msg["data"]["outcome"] = {
+        "conclusion": getOutcomeValuesFromVerdicts(
+            [
+                iterationsMap[iteration]["TCF1"],
+                iterationsMap[iteration]["TCF2"],
+            ],
+            "SUCCESSFUL",
+            "UNSUCCESSFUL",
+        )
+    }
 
-  return msg
+    return msg
+
 
 def generateTCT1(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelTestCaseTriggeredEvent", t, "1.0.0", "TCT1", iteration)
-  msg["data"]["testCase"] = {"tracker": "My First Test Management System", "id": "TC1", "uri": "http://tm.company.com/browse/TC1"}
-  link(msg, iterationsMap[iteration]["ActT1"], "CONTEXT")
-  link(msg, iterationsMap[iteration]["ArtC1"], "IUT")
-  return msg
+    msg = generateGenericMessage(
+        "EiffelTestCaseTriggeredEvent", t, "1.0.0", "TCT1", iteration
+    )
+    msg["data"]["testCase"] = {
+        "tracker": "My First Test Management System",
+        "id": "TC1",
+        "uri": "http://tm.company.com/browse/TC1",
+    }
+    link(msg, iterationsMap[iteration]["ActT1"], "CONTEXT")
+    link(msg, iterationsMap[iteration]["ArtC1"], "IUT")
+    return msg
+
 
 def generateTCS1(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelTestCaseStartedEvent", t, "1.0.0", "TCS1", iteration)
-  link(msg, iterationsMap[iteration]["TCT1"], "TEST_CASE_EXECUTION")
-  return msg
+    msg = generateGenericMessage(
+        "EiffelTestCaseStartedEvent", t, "1.0.0", "TCS1", iteration
+    )
+    link(msg, iterationsMap[iteration]["TCT1"], "TEST_CASE_EXECUTION")
+    return msg
+
 
 def generateTCF1(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelTestCaseFinishedEvent", t, "1.0.0", "TCF1", iteration)
-  link(msg, iterationsMap[iteration]["TCT1"], "TEST_CASE_EXECUTION")
-  msg["data"]["outcome"] = {"verdict": randomizeVerdict(0.95), "conclusion": "SUCCESSFUL"}
-  return msg
+    msg = generateGenericMessage(
+        "EiffelTestCaseFinishedEvent", t, "1.0.0", "TCF1", iteration
+    )
+    link(msg, iterationsMap[iteration]["TCT1"], "TEST_CASE_EXECUTION")
+    msg["data"]["outcome"] = {
+        "verdict": randomizeVerdict(0.95),
+        "conclusion": "SUCCESSFUL",
+    }
+    return msg
+
 
 def generateTCT2(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelTestCaseTriggeredEvent", t, "1.0.0", "TCT2", iteration)
-  msg["data"]["testCase"] = {"tracker": "My First Test Management System", "id": "TC2", "uri": "http://tm.company.com/browse/TC2"}
-  link(msg, iterationsMap[iteration]["ActT1"], "CONTEXT")
-  link(msg, iterationsMap[iteration]["ArtC1"], "IUT")
-  return msg
+    msg = generateGenericMessage(
+        "EiffelTestCaseTriggeredEvent", t, "1.0.0", "TCT2", iteration
+    )
+    msg["data"]["testCase"] = {
+        "tracker": "My First Test Management System",
+        "id": "TC2",
+        "uri": "http://tm.company.com/browse/TC2",
+    }
+    link(msg, iterationsMap[iteration]["ActT1"], "CONTEXT")
+    link(msg, iterationsMap[iteration]["ArtC1"], "IUT")
+    return msg
+
 
 def generateTCS2(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelTestCaseStartedEvent", t, "1.0.0", "TCS2", iteration)
-  link(msg, iterationsMap[iteration]["TCT2"], "TEST_CASE_EXECUTION")
-  return msg
+    msg = generateGenericMessage(
+        "EiffelTestCaseStartedEvent", t, "1.0.0", "TCS2", iteration
+    )
+    link(msg, iterationsMap[iteration]["TCT2"], "TEST_CASE_EXECUTION")
+    return msg
+
 
 def generateTCF2(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelTestCaseFinishedEvent", t, "1.0.0", "TCF2", iteration)
-  link(msg, iterationsMap[iteration]["TCT2"], "TEST_CASE_EXECUTION")
-  msg["data"]["outcome"] = {"verdict": randomizeVerdict(0.95), "conclusion": "SUCCESSFUL"}
-  return msg
+    msg = generateGenericMessage(
+        "EiffelTestCaseFinishedEvent", t, "1.0.0", "TCF2", iteration
+    )
+    link(msg, iterationsMap[iteration]["TCT2"], "TEST_CASE_EXECUTION")
+    msg["data"]["outcome"] = {
+        "verdict": randomizeVerdict(0.95),
+        "conclusion": "SUCCESSFUL",
+    }
+    return msg
+
 
 def generateActT2(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelActivityTriggeredEvent", t, "1.0.0", "ActT2", iteration)
-  link(msg, iterationsMap[iteration]["ArtP1"], "CAUSE")
-  msg["data"]["name"] = "Act2"
-  msg["data"]["categories"] = ["Test Activity"]
-  msg["data"]["triggers"] = [ {"type": "EIFFEL_EVENT"} ]
-  msg["data"]["executionType"] = "AUTOMATED"
-  return msg
+    msg = generateGenericMessage(
+        "EiffelActivityTriggeredEvent", t, "1.0.0", "ActT2", iteration
+    )
+    link(msg, iterationsMap[iteration]["ArtP1"], "CAUSE")
+    msg["data"]["name"] = "Act2"
+    msg["data"]["categories"] = ["Test Activity"]
+    msg["data"]["triggers"] = [{"type": "EIFFEL_EVENT"}]
+    msg["data"]["executionType"] = "AUTOMATED"
+    return msg
+
 
 def generateActS2(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelActivityStartedEvent", t, "1.0.0", "ActS2", iteration)
-  link(msg, iterationsMap[iteration]["ActT2"], "ACTIVITY_EXECUTION")
-  return msg
+    msg = generateGenericMessage(
+        "EiffelActivityStartedEvent", t, "1.0.0", "ActS2", iteration
+    )
+    link(msg, iterationsMap[iteration]["ActT2"], "ACTIVITY_EXECUTION")
+    return msg
+
 
 def generateActF2(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelActivityFinishedEvent", t, "1.0.0", "ActF2", iteration)
-  link(msg, iterationsMap[iteration]["ActT2"], "ACTIVITY_EXECUTION")
-  msg["data"]["outcome"] = {"conclusion": getOutcomeValuesFromVerdicts([iterationsMap[iteration]["TCF3"], iterationsMap[iteration]["TCF4"]], "SUCCESSFUL", "UNSUCCESSFUL")}
-  return msg
+    msg = generateGenericMessage(
+        "EiffelActivityFinishedEvent", t, "1.0.0", "ActF2", iteration
+    )
+    link(msg, iterationsMap[iteration]["ActT2"], "ACTIVITY_EXECUTION")
+    msg["data"]["outcome"] = {
+        "conclusion": getOutcomeValuesFromVerdicts(
+            [
+                iterationsMap[iteration]["TCF3"],
+                iterationsMap[iteration]["TCF4"],
+            ],
+            "SUCCESSFUL",
+            "UNSUCCESSFUL",
+        )
+    }
+    return msg
+
 
 def generateTCT3(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelTestCaseTriggeredEvent", t, "1.0.0", "TCT3", iteration)
-  msg["data"]["testCase"] = {"tracker": "My First Test Management System", "id": "TC3", "uri": "http://tm.company.com/browse/TC3"}
-  link(msg, iterationsMap[iteration]["ActT2"], "CONTEXT")
-  link(msg, iterationsMap[iteration]["ArtC1"], "IUT")
-  return msg
+    msg = generateGenericMessage(
+        "EiffelTestCaseTriggeredEvent", t, "1.0.0", "TCT3", iteration
+    )
+    msg["data"]["testCase"] = {
+        "tracker": "My First Test Management System",
+        "id": "TC3",
+        "uri": "http://tm.company.com/browse/TC3",
+    }
+    link(msg, iterationsMap[iteration]["ActT2"], "CONTEXT")
+    link(msg, iterationsMap[iteration]["ArtC1"], "IUT")
+    return msg
+
 
 def generateTCS3(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelTestCaseStartedEvent", t, "1.0.0", "TCS3", iteration)
-  link(msg, iterationsMap[iteration]["TCT3"], "TEST_CASE_EXECUTION")
-  return msg
+    msg = generateGenericMessage(
+        "EiffelTestCaseStartedEvent", t, "1.0.0", "TCS3", iteration
+    )
+    link(msg, iterationsMap[iteration]["TCT3"], "TEST_CASE_EXECUTION")
+    return msg
+
 
 def generateTCF3(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelTestCaseFinishedEvent", t, "1.0.0", "TCF3", iteration)
-  link(msg, iterationsMap[iteration]["TCT3"], "TEST_CASE_EXECUTION")
-  msg["data"]["outcome"] = {"verdict": randomizeVerdict(0.99), "conclusion": "SUCCESSFUL"}
-  return msg
+    msg = generateGenericMessage(
+        "EiffelTestCaseFinishedEvent", t, "1.0.0", "TCF3", iteration
+    )
+    link(msg, iterationsMap[iteration]["TCT3"], "TEST_CASE_EXECUTION")
+    msg["data"]["outcome"] = {
+        "verdict": randomizeVerdict(0.99),
+        "conclusion": "SUCCESSFUL",
+    }
+    return msg
+
 
 def generateTCT4(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelTestCaseTriggeredEvent", t, "1.0.0", "TCT4", iteration)
-  msg["data"]["testCase"] = {"tracker": "My First Test Management System", "id": "TC4", "uri": "http://tm.company.com/browse/TC4"}
-  link(msg, iterationsMap[iteration]["ActT2"], "CONTEXT")
-  link(msg, iterationsMap[iteration]["ArtC1"], "IUT")
-  return msg
+    msg = generateGenericMessage(
+        "EiffelTestCaseTriggeredEvent", t, "1.0.0", "TCT4", iteration
+    )
+    msg["data"]["testCase"] = {
+        "tracker": "My First Test Management System",
+        "id": "TC4",
+        "uri": "http://tm.company.com/browse/TC4",
+    }
+    link(msg, iterationsMap[iteration]["ActT2"], "CONTEXT")
+    link(msg, iterationsMap[iteration]["ArtC1"], "IUT")
+    return msg
+
 
 def generateTCS4(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelTestCaseStartedEvent", t, "1.0.0", "TCS4", iteration)
-  link(msg, iterationsMap[iteration]["TCT4"], "TEST_CASE_EXECUTION")
-  return msg
+    msg = generateGenericMessage(
+        "EiffelTestCaseStartedEvent", t, "1.0.0", "TCS4", iteration
+    )
+    link(msg, iterationsMap[iteration]["TCT4"], "TEST_CASE_EXECUTION")
+    return msg
+
 
 def generateTCF4(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelTestCaseFinishedEvent", t, "1.0.0", "TCF4", iteration)
-  link(msg, iterationsMap[iteration]["TCT4"], "TEST_CASE_EXECUTION")
-  msg["data"]["outcome"] = {"verdict": randomizeVerdict(0.90), "conclusion": "SUCCESSFUL"}
-  return msg
+    msg = generateGenericMessage(
+        "EiffelTestCaseFinishedEvent", t, "1.0.0", "TCF4", iteration
+    )
+    link(msg, iterationsMap[iteration]["TCT4"], "TEST_CASE_EXECUTION")
+    msg["data"]["outcome"] = {
+        "verdict": randomizeVerdict(0.90),
+        "conclusion": "SUCCESSFUL",
+    }
+    return msg
+
 
 def generateTCT5(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelTestCaseTriggeredEvent", t, "1.0.0", "TCT5", iteration)
-  msg["data"]["testCase"] = {"tracker": "My Other Test Management System", "id": "TC5", "uri": "https://other-tm.company.com/testCase/TC5"}
-  link(msg, iterationsMap[iteration]["TSS1"], "CONTEXT")
-  link(msg, iterationsMap[iteration]["ArtC2"], "IUT")
-  return msg
+    msg = generateGenericMessage(
+        "EiffelTestCaseTriggeredEvent", t, "1.0.0", "TCT5", iteration
+    )
+    msg["data"]["testCase"] = {
+        "tracker": "My Other Test Management System",
+        "id": "TC5",
+        "uri": "https://other-tm.company.com/testCase/TC5",
+    }
+    link(msg, iterationsMap[iteration]["TSS1"], "CONTEXT")
+    link(msg, iterationsMap[iteration]["ArtC2"], "IUT")
+    return msg
+
 
 def generateTCS5(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelTestCaseStartedEvent", t, "1.0.0", "TCS5", iteration)
-  link(msg, iterationsMap[iteration]["TCT5"], "TEST_CASE_EXECUTION")
-  return msg
+    msg = generateGenericMessage(
+        "EiffelTestCaseStartedEvent", t, "1.0.0", "TCS5", iteration
+    )
+    link(msg, iterationsMap[iteration]["TCT5"], "TEST_CASE_EXECUTION")
+    return msg
+
 
 def generateTCF5(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelTestCaseFinishedEvent", t, "1.0.0", "TCF5", iteration)
-  link(msg, iterationsMap[iteration]["TCT5"], "TEST_CASE_EXECUTION")
-  msg["data"]["outcome"] = {"verdict": randomizeVerdict(0.98), "conclusion": "SUCCESSFUL"}
-  return msg
+    msg = generateGenericMessage(
+        "EiffelTestCaseFinishedEvent", t, "1.0.0", "TCF5", iteration
+    )
+    link(msg, iterationsMap[iteration]["TCT5"], "TEST_CASE_EXECUTION")
+    msg["data"]["outcome"] = {
+        "verdict": randomizeVerdict(0.98),
+        "conclusion": "SUCCESSFUL",
+    }
+    return msg
+
 
 def generateTCT6(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelTestCaseTriggeredEvent", t, "1.0.0", "TCT6", iteration)
-  msg["data"]["testCase"] = {"tracker": "My Other Test Management System", "id": "TC6", "uri": "https://other-tm.company.com/testCase/TC6"}
-  link(msg, iterationsMap[iteration]["TSS1"], "CONTEXT")
-  link(msg, iterationsMap[iteration]["ArtC2"], "IUT")
-  return msg
+    msg = generateGenericMessage(
+        "EiffelTestCaseTriggeredEvent", t, "1.0.0", "TCT6", iteration
+    )
+    msg["data"]["testCase"] = {
+        "tracker": "My Other Test Management System",
+        "id": "TC6",
+        "uri": "https://other-tm.company.com/testCase/TC6",
+    }
+    link(msg, iterationsMap[iteration]["TSS1"], "CONTEXT")
+    link(msg, iterationsMap[iteration]["ArtC2"], "IUT")
+    return msg
+
 
 def generateTCS6(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelTestCaseStartedEvent", t, "1.0.0", "TCS6", iteration)
-  link(msg, iterationsMap[iteration]["TCT6"], "TEST_CASE_EXECUTION")
-  return msg
+    msg = generateGenericMessage(
+        "EiffelTestCaseStartedEvent", t, "1.0.0", "TCS6", iteration
+    )
+    link(msg, iterationsMap[iteration]["TCT6"], "TEST_CASE_EXECUTION")
+    return msg
+
 
 def generateTCF6(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelTestCaseFinishedEvent", t, "1.0.0", "TCF6", iteration)
-  link(msg, iterationsMap[iteration]["TCT6"], "TEST_CASE_EXECUTION")
-  msg["data"]["outcome"] = {"verdict": randomizeVerdict(0.98), "conclusion": "SUCCESSFUL"}
-  return msg
+    msg = generateGenericMessage(
+        "EiffelTestCaseFinishedEvent", t, "1.0.0", "TCF6", iteration
+    )
+    link(msg, iterationsMap[iteration]["TCT6"], "TEST_CASE_EXECUTION")
+    msg["data"]["outcome"] = {
+        "verdict": randomizeVerdict(0.98),
+        "conclusion": "SUCCESSFUL",
+    }
+    return msg
+
 
 def generateTCT7(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelTestCaseTriggeredEvent", t, "1.0.0", "TCT7", iteration)
-  msg["data"]["testCase"] = {"tracker": "My Other Test Management System", "id": "TC6", "uri": "https://other-tm.company.com/testCase/TC6"}
-  link(msg, iterationsMap[iteration]["TSS1"], "CONTEXT")
-  link(msg, iterationsMap[iteration]["ArtC2"], "IUT")
-  return msg
+    msg = generateGenericMessage(
+        "EiffelTestCaseTriggeredEvent", t, "1.0.0", "TCT7", iteration
+    )
+    msg["data"]["testCase"] = {
+        "tracker": "My Other Test Management System",
+        "id": "TC6",
+        "uri": "https://other-tm.company.com/testCase/TC6",
+    }
+    link(msg, iterationsMap[iteration]["TSS1"], "CONTEXT")
+    link(msg, iterationsMap[iteration]["ArtC2"], "IUT")
+    return msg
+
 
 def generateTCS7(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelTestCaseStartedEvent", t, "1.0.0", "TCS7", iteration)
-  link(msg, iterationsMap[iteration]["TCT7"], "TEST_CASE_EXECUTION")
-  return msg
+    msg = generateGenericMessage(
+        "EiffelTestCaseStartedEvent", t, "1.0.0", "TCS7", iteration
+    )
+    link(msg, iterationsMap[iteration]["TCT7"], "TEST_CASE_EXECUTION")
+    return msg
+
 
 def generateTCF7(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelTestCaseFinishedEvent", t, "1.0.0", "TCF7", iteration)
-  link(msg, iterationsMap[iteration]["TCT7"], "TEST_CASE_EXECUTION")
-  msg["data"]["outcome"] = {"verdict": randomizeVerdict(0.98), "conclusion": "SUCCESSFUL"}
-  return msg
+    msg = generateGenericMessage(
+        "EiffelTestCaseFinishedEvent", t, "1.0.0", "TCF7", iteration
+    )
+    link(msg, iterationsMap[iteration]["TCT7"], "TEST_CASE_EXECUTION")
+    msg["data"]["outcome"] = {
+        "verdict": randomizeVerdict(0.98),
+        "conclusion": "SUCCESSFUL",
+    }
+    return msg
+
 
 def generateTSS1(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelTestSuiteStartedEvent", t, "1.0.0", "TSS1", iteration)
-  link(msg, iterationsMap[iteration]["ActT3"], "CONTEXT")
-  msg["data"]["name"] = "My functional test suite"
-  msg["data"]["categories"] = ["Pre system integration tests"]
-  msg["data"]["types"] = ["FUNCTIONAL"]
-  return msg
+    msg = generateGenericMessage(
+        "EiffelTestSuiteStartedEvent", t, "1.0.0", "TSS1", iteration
+    )
+    link(msg, iterationsMap[iteration]["ActT3"], "CONTEXT")
+    msg["data"]["name"] = "My functional test suite"
+    msg["data"]["categories"] = ["Pre system integration tests"]
+    msg["data"]["types"] = ["FUNCTIONAL"]
+    return msg
+
 
 def generateTSF1(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelTestSuiteFinishedEvent", t, "1.0.0", "TSF1", iteration)
-  msg["data"]["outcome"] = {"verdict": getOutcomeValuesFromVerdicts([iterationsMap[iteration]["TCF5"], iterationsMap[iteration]["TCF6"], iterationsMap[iteration]["TCF7"]], "PASSED", "FAILED")}
-  link(msg, iterationsMap[iteration]["TSS1"], "TEST_SUITE_EXECUTION")
-  return msg
+    msg = generateGenericMessage(
+        "EiffelTestSuiteFinishedEvent", t, "1.0.0", "TSF1", iteration
+    )
+    msg["data"]["outcome"] = {
+        "verdict": getOutcomeValuesFromVerdicts(
+            [
+                iterationsMap[iteration]["TCF5"],
+                iterationsMap[iteration]["TCF6"],
+                iterationsMap[iteration]["TCF7"],
+            ],
+            "PASSED",
+            "FAILED",
+        )
+    }
+    link(msg, iterationsMap[iteration]["TSS1"], "TEST_SUITE_EXECUTION")
+    return msg
+
 
 def generateCLM1(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelConfidenceLevelModifiedEvent", t, "1.0.0", "CLM1", iteration)
-  link(msg, iterationsMap[iteration]["ArtC1"], "SUBJECT")
-  link(msg, iterationsMap[iteration]["TCF1"], "CAUSE")
-  link(msg, iterationsMap[iteration]["TCF2"], "CAUSE")
-  link(msg, iterationsMap[iteration]["TCF3"], "CAUSE")
-  link(msg, iterationsMap[iteration]["TCF4"], "CAUSE")
-  msg["data"]["name"] = "readyForRelease"
-  msg["data"]["value"] = getOutcomeValuesFromVerdicts([iterationsMap[iteration]["TCF1"], iterationsMap[iteration]["TCF2"], iterationsMap[iteration]["TCF3"], iterationsMap[iteration]["TCF4"]], "SUCCESS", "FAILURE")
-  return msg
+    msg = generateGenericMessage(
+        "EiffelConfidenceLevelModifiedEvent", t, "1.0.0", "CLM1", iteration
+    )
+    link(msg, iterationsMap[iteration]["ArtC1"], "SUBJECT")
+    link(msg, iterationsMap[iteration]["TCF1"], "CAUSE")
+    link(msg, iterationsMap[iteration]["TCF2"], "CAUSE")
+    link(msg, iterationsMap[iteration]["TCF3"], "CAUSE")
+    link(msg, iterationsMap[iteration]["TCF4"], "CAUSE")
+    msg["data"]["name"] = "readyForRelease"
+    msg["data"]["value"] = getOutcomeValuesFromVerdicts(
+        [
+            iterationsMap[iteration]["TCF1"],
+            iterationsMap[iteration]["TCF2"],
+            iterationsMap[iteration]["TCF3"],
+            iterationsMap[iteration]["TCF4"],
+        ],
+        "SUCCESS",
+        "FAILURE",
+    )
+    return msg
+
 
 def generateCLM2(iterationsMap, iteration, t):
-  msg = generateGenericMessage("EiffelConfidenceLevelModifiedEvent", t, "1.0.0", "CLM2", iteration)
-  msg["data"]["name"] = "readyForSystemIntegration"
-  msg["data"]["value"] = getOutcomeValuesFromVerdicts([iterationsMap[iteration]["TSF1"]], "SUCCESS", "FAILURE")
-  link(msg, iterationsMap[iteration]["TSF1"], "CAUSE")
-  link(msg, iterationsMap[iteration]["ArtC2"], "SUBJECT")
-  return msg
+    msg = generateGenericMessage(
+        "EiffelConfidenceLevelModifiedEvent", t, "1.0.0", "CLM2", iteration
+    )
+    msg["data"]["name"] = "readyForSystemIntegration"
+    msg["data"]["value"] = getOutcomeValuesFromVerdicts(
+        [iterationsMap[iteration]["TSF1"]], "SUCCESS", "FAILURE"
+    )
+    link(msg, iterationsMap[iteration]["TSF1"], "CAUSE")
+    link(msg, iterationsMap[iteration]["ArtC2"], "SUBJECT")
+    return msg
+
 
 def buildMsgArrayFromiterationsMap(iterationsMap):
-  globalArray = []
-  for key, itMap in iterationsMap.items():
-    if itMap:
-      globalArray.extend(buildMsgArrayFromIterationMap(itMap))
+    globalArray = []
+    for key, itMap in iterationsMap.items():
+        if itMap:
+            globalArray.extend(buildMsgArrayFromIterationMap(itMap))
 
-  return globalArray
+    return globalArray
+
 
 def buildMsgArrayFromIterationMap(iterationMap):
-  msgArray = []
-  for msg in iterationMap.values():
-    msgArray.append(msg)
+    msgArray = []
+    for msg in iterationMap.values():
+        msgArray.append(msg)
 
-  return msgArray
+    return msgArray
+
 
 def generateIterationZeroMessages(iterationsMap, t):
-  iterationsMap[0] = {}
-  iterationsMap[0]["SCS1"] = generateSCS1(iterationsMap, 0, t)
-  t += 1
-  iterationsMap[0]["EDef1"] = generateEDef1(iterationsMap, 0, t)
-  t += 1
-  iterationsMap[0]["EDef2"] = generateEDef2(iterationsMap, 0, t)
-  t += 1
-  iterationsMap[0]["ArtC3"] = generateArtC3(iterationsMap, 0, t)
-  t += 1
-  iterationsMap[0]["CDef3"] = generateCDef3(iterationsMap, 0, t)
-  t += 1
-  iterationsMap[0]["ArtCC1"] = generateArtCC1(iterationsMap, 0, t)
-  t += 1
-  iterationsMap[0]["ArtCC2"] = generateArtCC2(iterationsMap, 0, t)
-  t += 1
-  iterationsMap[0]["ArtCC3"] = generateArtCC3(iterationsMap, 0, t)
+    iterationsMap[0] = {}
+    iterationsMap[0]["SCS1"] = generateSCS1(iterationsMap, 0, t)
+    t += 1
+    iterationsMap[0]["EDef1"] = generateEDef1(iterationsMap, 0, t)
+    t += 1
+    iterationsMap[0]["EDef2"] = generateEDef2(iterationsMap, 0, t)
+    t += 1
+    iterationsMap[0]["ArtC3"] = generateArtC3(iterationsMap, 0, t)
+    t += 1
+    iterationsMap[0]["CDef3"] = generateCDef3(iterationsMap, 0, t)
+    t += 1
+    iterationsMap[0]["ArtCC1"] = generateArtCC1(iterationsMap, 0, t)
+    t += 1
+    iterationsMap[0]["ArtCC2"] = generateArtCC2(iterationsMap, 0, t)
+    t += 1
+    iterationsMap[0]["ArtCC3"] = generateArtCC3(iterationsMap, 0, t)
 
-  return t
+    return t
+
 
 def generateComponentBuildEvents(iterationsMap, iteration, t):
-  t += 1
-  iterationsMap[iteration]["SCC1"] = generateSCC1(iterationsMap, iteration, t)
-  t += 1
-  iterationsMap[iteration]["SCS1"] = generateSCS1(iterationsMap, iteration, t)
-  t += 100
-  iterationsMap[iteration]["CDef3"] = generateCDef3(iterationsMap, iteration, t)
+    t += 1
+    iterationsMap[iteration]["SCC1"] = generateSCC1(
+        iterationsMap, iteration, t
+    )
+    t += 1
+    iterationsMap[iteration]["SCS1"] = generateSCS1(
+        iterationsMap, iteration, t
+    )
+    t += 100
+    iterationsMap[iteration]["CDef3"] = generateCDef3(
+        iterationsMap, iteration, t
+    )
 
-  if random.random() < 0.5:
-    t += 200000
-    iterationsMap[iteration]["ArtCC1"] = generateArtCC1(iterationsMap, iteration, t)
+    if random.random() < 0.5:
+        t += 200000
+        iterationsMap[iteration]["ArtCC1"] = generateArtCC1(
+            iterationsMap, iteration, t
+        )
 
-  if random.random() < 0.5:
-    t += 35000
-    iterationsMap[iteration]["ArtCC2"] = generateArtCC2(iterationsMap, iteration, t)
+    if random.random() < 0.5:
+        t += 35000
+        iterationsMap[iteration]["ArtCC2"] = generateArtCC2(
+            iterationsMap, iteration, t
+        )
 
-  t += 1000
-  iterationsMap[iteration]["ArtCC3"] = generateArtCC3(iterationsMap, iteration, t)
+    t += 1000
+    iterationsMap[iteration]["ArtCC3"] = generateArtCC3(
+        iterationsMap, iteration, t
+    )
 
-  return t
+    return t
+
 
 def generateSubSystemBuildEvents(iterationsMap, iteration, t):
-  t += 100
-  iterationsMap[iteration]["ActT4"] = generateActT4(iterationsMap, iteration, t)
-  t += 1
-  iterationsMap[iteration]["ActS4"] = generateActS4(iterationsMap, iteration, t)
-  t += 100
-  iterationsMap[iteration]["CDef2"] = generateCDef2(iterationsMap, iteration, t)
-
-  if random.random() < 0.95:
     t += 100
-    iterationsMap[iteration]["ArtC2"] = generateArtC2(iterationsMap, iteration, t)
-    t += 30000
-    iterationsMap[iteration]["ArtP2"] = generateArtP2(iterationsMap, iteration, t)
+    iterationsMap[iteration]["ActT4"] = generateActT4(
+        iterationsMap, iteration, t
+    )
+    t += 1
+    iterationsMap[iteration]["ActS4"] = generateActS4(
+        iterationsMap, iteration, t
+    )
+    t += 100
+    iterationsMap[iteration]["CDef2"] = generateCDef2(
+        iterationsMap, iteration, t
+    )
 
-  t += 50
-  iterationsMap[iteration]["ActF4"] = generateActF4(iterationsMap, iteration, t)
+    if random.random() < 0.95:
+        t += 100
+        iterationsMap[iteration]["ArtC2"] = generateArtC2(
+            iterationsMap, iteration, t
+        )
+        t += 30000
+        iterationsMap[iteration]["ArtP2"] = generateArtP2(
+            iterationsMap, iteration, t
+        )
 
-  return t
+    t += 50
+    iterationsMap[iteration]["ActF4"] = generateActF4(
+        iterationsMap, iteration, t
+    )
+
+    return t
+
 
 def generateSubSystemTestEvents(iterationsMap, iteration, t):
-  t += 2000
-  iterationsMap[iteration]["ActT3"] = generateActT3(iterationsMap, iteration, t)
-  t += 3
-  iterationsMap[iteration]["ActS3"] = generateActS3(iterationsMap, iteration, t)
-  t += 2000
-  iterationsMap[iteration]["TSS1"] = generateTSS1(iterationsMap, iteration, t)
-  t += 100
-  iterationsMap[iteration]["TCT5"] = generateTCT5(iterationsMap, iteration, t)
-  t += 1
-  iterationsMap[iteration]["TCT6"] = generateTCT6(iterationsMap, iteration, t)
-  t += 1
-  iterationsMap[iteration]["TCT7"] = generateTCT7(iterationsMap, iteration, t)
-  t += 1
-  iterationsMap[iteration]["TCS5"] = generateTCS5(iterationsMap, iteration, t)
-  t += 2
-  iterationsMap[iteration]["TCS6"] = generateTCS6(iterationsMap, iteration, t)
-  t += 1
-  iterationsMap[iteration]["TCS7"] = generateTCS7(iterationsMap, iteration, t)
-  t += 10000
-  iterationsMap[iteration]["TCF5"] = generateTCF5(iterationsMap, iteration, t)
-  t += 3000
-  iterationsMap[iteration]["TCF6"] = generateTCF6(iterationsMap, iteration, t)
-  t += 5000
-  iterationsMap[iteration]["TCF7"] = generateTCF7(iterationsMap, iteration, t)
-  t += 50
-  iterationsMap[iteration]["TSF1"] = generateTSF1(iterationsMap, iteration, t)
-  t += 3
-  iterationsMap[iteration]["ActF3"] = generateActF3(iterationsMap, iteration, t)
-  t += 300
-  iterationsMap[iteration]["CLM2"] = generateCLM2(iterationsMap, iteration, t)
+    t += 2000
+    iterationsMap[iteration]["ActT3"] = generateActT3(
+        iterationsMap, iteration, t
+    )
+    t += 3
+    iterationsMap[iteration]["ActS3"] = generateActS3(
+        iterationsMap, iteration, t
+    )
+    t += 2000
+    iterationsMap[iteration]["TSS1"] = generateTSS1(
+        iterationsMap, iteration, t
+    )
+    t += 100
+    iterationsMap[iteration]["TCT5"] = generateTCT5(
+        iterationsMap, iteration, t
+    )
+    t += 1
+    iterationsMap[iteration]["TCT6"] = generateTCT6(
+        iterationsMap, iteration, t
+    )
+    t += 1
+    iterationsMap[iteration]["TCT7"] = generateTCT7(
+        iterationsMap, iteration, t
+    )
+    t += 1
+    iterationsMap[iteration]["TCS5"] = generateTCS5(
+        iterationsMap, iteration, t
+    )
+    t += 2
+    iterationsMap[iteration]["TCS6"] = generateTCS6(
+        iterationsMap, iteration, t
+    )
+    t += 1
+    iterationsMap[iteration]["TCS7"] = generateTCS7(
+        iterationsMap, iteration, t
+    )
+    t += 10000
+    iterationsMap[iteration]["TCF5"] = generateTCF5(
+        iterationsMap, iteration, t
+    )
+    t += 3000
+    iterationsMap[iteration]["TCF6"] = generateTCF6(
+        iterationsMap, iteration, t
+    )
+    t += 5000
+    iterationsMap[iteration]["TCF7"] = generateTCF7(
+        iterationsMap, iteration, t
+    )
+    t += 50
+    iterationsMap[iteration]["TSF1"] = generateTSF1(
+        iterationsMap, iteration, t
+    )
+    t += 3
+    iterationsMap[iteration]["ActF3"] = generateActF3(
+        iterationsMap, iteration, t
+    )
+    t += 300
+    iterationsMap[iteration]["CLM2"] = generateCLM2(
+        iterationsMap, iteration, t
+    )
 
-  return t
+    return t
+
 
 def generateSystemIntegrationEvents(iterationsMap, iteration, t):
-  t += 300
-  iterationsMap[iteration]["CDef1"] = generateCDef1(iterationsMap, iteration, t)
-  t += 1000
-  iterationsMap[iteration]["ArtC1"] = generateArtC1(iterationsMap, iteration, t)
-  t += 1000
-  iterationsMap[iteration]["ArtP1"] = generateArtP1(iterationsMap, iteration, t)
-  t += 1000
-  iterationsMap[iteration]["ActT1"] = generateActT1(iterationsMap, iteration, t)
-  t += 2
-  iterationsMap[iteration]["ActS1"] = generateActS1(iterationsMap, iteration, t)
-  t += 50
-  iterationsMap[iteration]["ActT2"] = generateActT2(iterationsMap, iteration, t)
-  t += 1
-  iterationsMap[iteration]["TCT1"] = generateTCT1(iterationsMap, iteration, t)
-  t += 1
-  iterationsMap[iteration]["TCT2"] = generateTCT2(iterationsMap, iteration, t)
-  t += 1000
-  iterationsMap[iteration]["TCS1"] = generateTCS1(iterationsMap, iteration, t)
-  t += 100
-  iterationsMap[iteration]["TCS2"] = generateTCS2(iterationsMap, iteration, t)
-  t += 50000
-  iterationsMap[iteration]["TCF2"] = generateTCF2(iterationsMap, iteration, t)
-  t += 3000
-  iterationsMap[iteration]["TCF1"] = generateTCF1(iterationsMap, iteration, t)
-  t += 100
-  iterationsMap[iteration]["ActF1"] = generateActF1(iterationsMap, iteration, t)
-  t += 100000
-  iterationsMap[iteration]["ActS2"] = generateActS2(iterationsMap, iteration, t)
-  t += 1
-  iterationsMap[iteration]["TCT3"] = generateTCT3(iterationsMap, iteration, t)
-  t += 200
-  iterationsMap[iteration]["TCS3"] = generateTCS3(iterationsMap, iteration, t)
-  t += 10000
-  iterationsMap[iteration]["TCF3"] = generateTCF3(iterationsMap, iteration, t)
-  t += 1
-  iterationsMap[iteration]["TCT4"] = generateTCT4(iterationsMap, iteration, t)
-  t += 100
-  iterationsMap[iteration]["TCS4"] = generateTCS4(iterationsMap, iteration, t)
-  t += 120000
-  iterationsMap[iteration]["TCF4"] = generateTCF4(iterationsMap, iteration, t)
-  t += 20
-  iterationsMap[iteration]["ActF2"] = generateActF2(iterationsMap, iteration, t)
-  t += 2500
-  iterationsMap[iteration]["CLM1"] = generateCLM1(iterationsMap, iteration, t)
+    t += 300
+    iterationsMap[iteration]["CDef1"] = generateCDef1(
+        iterationsMap, iteration, t
+    )
+    t += 1000
+    iterationsMap[iteration]["ArtC1"] = generateArtC1(
+        iterationsMap, iteration, t
+    )
+    t += 1000
+    iterationsMap[iteration]["ArtP1"] = generateArtP1(
+        iterationsMap, iteration, t
+    )
+    t += 1000
+    iterationsMap[iteration]["ActT1"] = generateActT1(
+        iterationsMap, iteration, t
+    )
+    t += 2
+    iterationsMap[iteration]["ActS1"] = generateActS1(
+        iterationsMap, iteration, t
+    )
+    t += 50
+    iterationsMap[iteration]["ActT2"] = generateActT2(
+        iterationsMap, iteration, t
+    )
+    t += 1
+    iterationsMap[iteration]["TCT1"] = generateTCT1(
+        iterationsMap, iteration, t
+    )
+    t += 1
+    iterationsMap[iteration]["TCT2"] = generateTCT2(
+        iterationsMap, iteration, t
+    )
+    t += 1000
+    iterationsMap[iteration]["TCS1"] = generateTCS1(
+        iterationsMap, iteration, t
+    )
+    t += 100
+    iterationsMap[iteration]["TCS2"] = generateTCS2(
+        iterationsMap, iteration, t
+    )
+    t += 50000
+    iterationsMap[iteration]["TCF2"] = generateTCF2(
+        iterationsMap, iteration, t
+    )
+    t += 3000
+    iterationsMap[iteration]["TCF1"] = generateTCF1(
+        iterationsMap, iteration, t
+    )
+    t += 100
+    iterationsMap[iteration]["ActF1"] = generateActF1(
+        iterationsMap, iteration, t
+    )
+    t += 100000
+    iterationsMap[iteration]["ActS2"] = generateActS2(
+        iterationsMap, iteration, t
+    )
+    t += 1
+    iterationsMap[iteration]["TCT3"] = generateTCT3(
+        iterationsMap, iteration, t
+    )
+    t += 200
+    iterationsMap[iteration]["TCS3"] = generateTCS3(
+        iterationsMap, iteration, t
+    )
+    t += 10000
+    iterationsMap[iteration]["TCF3"] = generateTCF3(
+        iterationsMap, iteration, t
+    )
+    t += 1
+    iterationsMap[iteration]["TCT4"] = generateTCT4(
+        iterationsMap, iteration, t
+    )
+    t += 100
+    iterationsMap[iteration]["TCS4"] = generateTCS4(
+        iterationsMap, iteration, t
+    )
+    t += 120000
+    iterationsMap[iteration]["TCF4"] = generateTCF4(
+        iterationsMap, iteration, t
+    )
+    t += 20
+    iterationsMap[iteration]["ActF2"] = generateActF2(
+        iterationsMap, iteration, t
+    )
+    t += 2500
+    iterationsMap[iteration]["CLM1"] = generateCLM1(
+        iterationsMap, iteration, t
+    )
 
-  return t
+    return t
+
 
 def generateIterationMessages(iterationsMap, iteration, t):
-  iterationsMap[iteration] = {}
-  t = generateComponentBuildEvents(iterationsMap, iteration, t)
-  t = generateSubSystemBuildEvents(iterationsMap, iteration, t)
+    iterationsMap[iteration] = {}
+    t = generateComponentBuildEvents(iterationsMap, iteration, t)
+    t = generateSubSystemBuildEvents(iterationsMap, iteration, t)
 
-  if "ArtC2" in iterationsMap[iteration]:
-    t = generateSubSystemTestEvents(iterationsMap, iteration, t)
-    if iterationsMap[iteration]["CLM2"]["data"]["value"] == "SUCCESS":
-      t = generateSystemIntegrationEvents(iterationsMap, iteration, t)
+    if "ArtC2" in iterationsMap[iteration]:
+        t = generateSubSystemTestEvents(iterationsMap, iteration, t)
+        if iterationsMap[iteration]["CLM2"]["data"]["value"] == "SUCCESS":
+            t = generateSystemIntegrationEvents(iterationsMap, iteration, t)
 
-  return t
+    return t
+
 
 def main(iterations):
-  t = int(time.time() * 1000)
+    t = int(time.time() * 1000)
 
-  iterationsMap = {}
+    iterationsMap = {}
 
-  t = generateIterationZeroMessages(iterationsMap, t)
+    t = generateIterationZeroMessages(iterationsMap, t)
 
-  for iteration in range(1, iterations + 1):
-    t += 10000
-    t = generateIterationMessages(iterationsMap, iteration, t)
+    for iteration in range(1, iterations + 1):
+        t += 10000
+        t = generateIterationMessages(iterationsMap, iteration, t)
 
-  out = buildMsgArrayFromiterationsMap(iterationsMap)
+    out = buildMsgArrayFromiterationsMap(iterationsMap)
 
-  out.sort(key=lambda x: x["meta"]["time"], reverse=False)
-  print(json.dumps(out, indent=2, separators=(",", ": ")))
+    out.sort(key=lambda x: x["meta"]["time"], reverse=False)
+    print(json.dumps(out, indent=2, separators=(",", ": ")))
+
 
 def usage():
-  print("-h, --help")
-  print("    Print this text.")
-  print("-i ..., --iterations=...")
-  print("    Specify the number of iterations to create.")
-  print("    Default: 1")
+    print("-h, --help")
+    print("    Print this text.")
+    print("-i ..., --iterations=...")
+    print("    Specify the number of iterations to create.")
+    print("    Default: 1")
+
 
 try:
-  opts, args = getopt.getopt(sys.argv[1:], "hi:", ["help", "iterations="])
+    opts, args = getopt.getopt(sys.argv[1:], "hi:", ["help", "iterations="])
 except getopt.GetoptError:
-  usage()
-  sys.exit(2)
+    usage()
+    sys.exit(2)
 
 iterations = 1
 
 for opt, arg in opts:
-  if opt in ("-h", "--help"):
-    usage()
-    sys.exit()
-  elif opt in ("-i", "--iterations"):
-    iterations = int(arg)
+    if opt in ("-h", "--help"):
+        usage()
+        sys.exit()
+    elif opt in ("-i", "--iterations"):
+        iterations = int(arg)
 
 main(iterations)

--- a/examples/reference-data-sets/default/generator.py
+++ b/examples/reference-data-sets/default/generator.py
@@ -238,9 +238,7 @@ def generateArtC1(iterationsMap, iteration, t):
         "PREVIOUS_VERSION",
     )
     msg["data"]["identity"] = (
-        "pkg:maven/com.mycompany.myproduct/complete-system@1."
-        + str(iteration)
-        + ".0"
+        "pkg:maven/com.mycompany.myproduct/complete-system@1." + str(iteration) + ".0"
     )
     return msg
 
@@ -258,9 +256,7 @@ def generateArtC2(iterationsMap, iteration, t):
     )
     link(msg, iterationsMap[iteration]["ActT4"], "CONTEXT")
     msg["data"]["identity"] = (
-        "pkg:maven/com.mycompany.myproduct/sub-system@1."
-        + str(iteration)
-        + ".0"
+        "pkg:maven/com.mycompany.myproduct/sub-system@1." + str(iteration) + ".0"
     )
     return msg
 
@@ -277,9 +273,7 @@ def generateArtCC1(iterationsMap, iteration, t):
         "PREVIOUS_VERSION",
     )
     msg["data"]["identity"] = (
-        "pkg:maven/com.mycompany.myproduct/component-1@1."
-        + str(iteration)
-        + ".0"
+        "pkg:maven/com.mycompany.myproduct/component-1@1." + str(iteration) + ".0"
     )
     return msg
 
@@ -296,9 +290,7 @@ def generateArtCC2(iterationsMap, iteration, t):
         "PREVIOUS_VERSION",
     )
     msg["data"]["identity"] = (
-        "pkg:maven/com.mycompany.myproduct/component-2@1."
-        + str(iteration)
-        + ".0"
+        "pkg:maven/com.mycompany.myproduct/component-2@1." + str(iteration) + ".0"
     )
     return msg
 
@@ -315,9 +307,7 @@ def generateArtCC3(iterationsMap, iteration, t):
         "PREVIOUS_VERSION",
     )
     msg["data"]["identity"] = (
-        "pkg:maven/com.mycompany.myproduct/component-3@1."
-        + str(iteration)
-        + ".0"
+        "pkg:maven/com.mycompany.myproduct/component-3@1." + str(iteration) + ".0"
     )
     return msg
 
@@ -845,224 +835,126 @@ def generateIterationZeroMessages(iterationsMap, t):
 
 def generateComponentBuildEvents(iterationsMap, iteration, t):
     t += 1
-    iterationsMap[iteration]["SCC1"] = generateSCC1(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["SCC1"] = generateSCC1(iterationsMap, iteration, t)
     t += 1
-    iterationsMap[iteration]["SCS1"] = generateSCS1(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["SCS1"] = generateSCS1(iterationsMap, iteration, t)
     t += 100
-    iterationsMap[iteration]["CDef3"] = generateCDef3(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["CDef3"] = generateCDef3(iterationsMap, iteration, t)
 
     if random.random() < 0.5:
         t += 200000
-        iterationsMap[iteration]["ArtCC1"] = generateArtCC1(
-            iterationsMap, iteration, t
-        )
+        iterationsMap[iteration]["ArtCC1"] = generateArtCC1(iterationsMap, iteration, t)
 
     if random.random() < 0.5:
         t += 35000
-        iterationsMap[iteration]["ArtCC2"] = generateArtCC2(
-            iterationsMap, iteration, t
-        )
+        iterationsMap[iteration]["ArtCC2"] = generateArtCC2(iterationsMap, iteration, t)
 
     t += 1000
-    iterationsMap[iteration]["ArtCC3"] = generateArtCC3(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["ArtCC3"] = generateArtCC3(iterationsMap, iteration, t)
 
     return t
 
 
 def generateSubSystemBuildEvents(iterationsMap, iteration, t):
     t += 100
-    iterationsMap[iteration]["ActT4"] = generateActT4(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["ActT4"] = generateActT4(iterationsMap, iteration, t)
     t += 1
-    iterationsMap[iteration]["ActS4"] = generateActS4(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["ActS4"] = generateActS4(iterationsMap, iteration, t)
     t += 100
-    iterationsMap[iteration]["CDef2"] = generateCDef2(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["CDef2"] = generateCDef2(iterationsMap, iteration, t)
 
     if random.random() < 0.95:
         t += 100
-        iterationsMap[iteration]["ArtC2"] = generateArtC2(
-            iterationsMap, iteration, t
-        )
+        iterationsMap[iteration]["ArtC2"] = generateArtC2(iterationsMap, iteration, t)
         t += 30000
-        iterationsMap[iteration]["ArtP2"] = generateArtP2(
-            iterationsMap, iteration, t
-        )
+        iterationsMap[iteration]["ArtP2"] = generateArtP2(iterationsMap, iteration, t)
 
     t += 50
-    iterationsMap[iteration]["ActF4"] = generateActF4(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["ActF4"] = generateActF4(iterationsMap, iteration, t)
 
     return t
 
 
 def generateSubSystemTestEvents(iterationsMap, iteration, t):
     t += 2000
-    iterationsMap[iteration]["ActT3"] = generateActT3(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["ActT3"] = generateActT3(iterationsMap, iteration, t)
     t += 3
-    iterationsMap[iteration]["ActS3"] = generateActS3(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["ActS3"] = generateActS3(iterationsMap, iteration, t)
     t += 2000
-    iterationsMap[iteration]["TSS1"] = generateTSS1(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["TSS1"] = generateTSS1(iterationsMap, iteration, t)
     t += 100
-    iterationsMap[iteration]["TCT5"] = generateTCT5(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["TCT5"] = generateTCT5(iterationsMap, iteration, t)
     t += 1
-    iterationsMap[iteration]["TCT6"] = generateTCT6(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["TCT6"] = generateTCT6(iterationsMap, iteration, t)
     t += 1
-    iterationsMap[iteration]["TCT7"] = generateTCT7(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["TCT7"] = generateTCT7(iterationsMap, iteration, t)
     t += 1
-    iterationsMap[iteration]["TCS5"] = generateTCS5(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["TCS5"] = generateTCS5(iterationsMap, iteration, t)
     t += 2
-    iterationsMap[iteration]["TCS6"] = generateTCS6(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["TCS6"] = generateTCS6(iterationsMap, iteration, t)
     t += 1
-    iterationsMap[iteration]["TCS7"] = generateTCS7(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["TCS7"] = generateTCS7(iterationsMap, iteration, t)
     t += 10000
-    iterationsMap[iteration]["TCF5"] = generateTCF5(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["TCF5"] = generateTCF5(iterationsMap, iteration, t)
     t += 3000
-    iterationsMap[iteration]["TCF6"] = generateTCF6(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["TCF6"] = generateTCF6(iterationsMap, iteration, t)
     t += 5000
-    iterationsMap[iteration]["TCF7"] = generateTCF7(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["TCF7"] = generateTCF7(iterationsMap, iteration, t)
     t += 50
-    iterationsMap[iteration]["TSF1"] = generateTSF1(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["TSF1"] = generateTSF1(iterationsMap, iteration, t)
     t += 3
-    iterationsMap[iteration]["ActF3"] = generateActF3(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["ActF3"] = generateActF3(iterationsMap, iteration, t)
     t += 300
-    iterationsMap[iteration]["CLM2"] = generateCLM2(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["CLM2"] = generateCLM2(iterationsMap, iteration, t)
 
     return t
 
 
 def generateSystemIntegrationEvents(iterationsMap, iteration, t):
     t += 300
-    iterationsMap[iteration]["CDef1"] = generateCDef1(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["CDef1"] = generateCDef1(iterationsMap, iteration, t)
     t += 1000
-    iterationsMap[iteration]["ArtC1"] = generateArtC1(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["ArtC1"] = generateArtC1(iterationsMap, iteration, t)
     t += 1000
-    iterationsMap[iteration]["ArtP1"] = generateArtP1(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["ArtP1"] = generateArtP1(iterationsMap, iteration, t)
     t += 1000
-    iterationsMap[iteration]["ActT1"] = generateActT1(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["ActT1"] = generateActT1(iterationsMap, iteration, t)
     t += 2
-    iterationsMap[iteration]["ActS1"] = generateActS1(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["ActS1"] = generateActS1(iterationsMap, iteration, t)
     t += 50
-    iterationsMap[iteration]["ActT2"] = generateActT2(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["ActT2"] = generateActT2(iterationsMap, iteration, t)
     t += 1
-    iterationsMap[iteration]["TCT1"] = generateTCT1(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["TCT1"] = generateTCT1(iterationsMap, iteration, t)
     t += 1
-    iterationsMap[iteration]["TCT2"] = generateTCT2(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["TCT2"] = generateTCT2(iterationsMap, iteration, t)
     t += 1000
-    iterationsMap[iteration]["TCS1"] = generateTCS1(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["TCS1"] = generateTCS1(iterationsMap, iteration, t)
     t += 100
-    iterationsMap[iteration]["TCS2"] = generateTCS2(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["TCS2"] = generateTCS2(iterationsMap, iteration, t)
     t += 50000
-    iterationsMap[iteration]["TCF2"] = generateTCF2(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["TCF2"] = generateTCF2(iterationsMap, iteration, t)
     t += 3000
-    iterationsMap[iteration]["TCF1"] = generateTCF1(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["TCF1"] = generateTCF1(iterationsMap, iteration, t)
     t += 100
-    iterationsMap[iteration]["ActF1"] = generateActF1(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["ActF1"] = generateActF1(iterationsMap, iteration, t)
     t += 100000
-    iterationsMap[iteration]["ActS2"] = generateActS2(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["ActS2"] = generateActS2(iterationsMap, iteration, t)
     t += 1
-    iterationsMap[iteration]["TCT3"] = generateTCT3(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["TCT3"] = generateTCT3(iterationsMap, iteration, t)
     t += 200
-    iterationsMap[iteration]["TCS3"] = generateTCS3(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["TCS3"] = generateTCS3(iterationsMap, iteration, t)
     t += 10000
-    iterationsMap[iteration]["TCF3"] = generateTCF3(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["TCF3"] = generateTCF3(iterationsMap, iteration, t)
     t += 1
-    iterationsMap[iteration]["TCT4"] = generateTCT4(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["TCT4"] = generateTCT4(iterationsMap, iteration, t)
     t += 100
-    iterationsMap[iteration]["TCS4"] = generateTCS4(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["TCS4"] = generateTCS4(iterationsMap, iteration, t)
     t += 120000
-    iterationsMap[iteration]["TCF4"] = generateTCF4(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["TCF4"] = generateTCF4(iterationsMap, iteration, t)
     t += 20
-    iterationsMap[iteration]["ActF2"] = generateActF2(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["ActF2"] = generateActF2(iterationsMap, iteration, t)
     t += 2500
-    iterationsMap[iteration]["CLM1"] = generateCLM1(
-        iterationsMap, iteration, t
-    )
+    iterationsMap[iteration]["CLM1"] = generateCLM1(iterationsMap, iteration, t)
 
     return t
 

--- a/examples/reference-data-sets/default/generator.py
+++ b/examples/reference-data-sets/default/generator.py
@@ -15,12 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
-import uuid
-import time
 import getopt
-import sys
+import json
 import random
+import sys
+import time
+import uuid
 
 
 def generateGenericMeta(type, t, v):

--- a/examples/validate.py
+++ b/examples/validate.py
@@ -15,16 +15,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
+import fnmatch
+import getopt
 import json
 import os
-import fnmatch
-import zipfile
 import random
-import string
 import shutil
+import string
+import sys
 import time
-import getopt
+import zipfile
+
 from jsonschema import validate
 
 

--- a/examples/validate.py
+++ b/examples/validate.py
@@ -36,9 +36,7 @@ def extractArchives():
             archivePath = os.path.join(root, fileName)
             extractionPath = os.path.join(
                 "examples",
-                "".join(
-                    random.choice(string.ascii_lowercase) for i in range(16)
-                ),
+                "".join(random.choice(string.ascii_lowercase) for i in range(16)),
             )
             extractionPaths.append(extractionPath)
             print(
@@ -155,20 +153,12 @@ def report(
 ):
     for path, type, id, o in unchecked:
         print(
-            "ERROR: Missing schema for "
-            + id
-            + "("
-            + type
-            + ") in "
-            + path
-            + ".",
+            "ERROR: Missing schema for " + id + "(" + type + ") in " + path + ".",
             flush=True,
         )
 
     for badSchemaFile in badSchemaFiles:
-        print(
-            "ERROR: Failed to load schema from file", badSchemaFile, flush=True
-        )
+        print("ERROR: Failed to load schema from file", badSchemaFile, flush=True)
 
     for badExampleFile in badExampleFiles:
         print(
@@ -226,19 +216,14 @@ def main(maxExamples, includeArchives, shuffle):
     )
 
     if (
-        len(badSchemaFiles)
-        + len(badExampleFiles)
-        + len(failures)
-        + len(unchecked)
+        len(badSchemaFiles) + len(badExampleFiles) + len(failures) + len(unchecked)
     ) > 0:
         sys.exit("Validation failed.")
 
 
 def usage():
     print("Usage:")
-    print(
-        "    This script will validate .json files in the examples directory."
-    )
+    print("    This script will validate .json files in the examples directory.")
     print("")
     print("Arguments:")
     print("    -m, --max-examples <number>")

--- a/examples/validate.py
+++ b/examples/validate.py
@@ -110,16 +110,16 @@ def validateExamples(examples, schemas, maxExamples, shuffle):
 
     if shuffle:
         random.shuffle(examples)
-    for path, type, version, id, json in examples:
+    for path, type, version, id, event in examples:
         schemaKey = type + "-" + version
         if schemaKey in schemas:
             try:
-                validate(json, schemas[schemaKey])
+                validate(event, schemas[schemaKey])
                 numberOfSuccessfulValidations += 1
             except Exception as e:
                 failures.append((path, type, id, e))
         else:
-            unchecked.append((path, type, id, json))
+            unchecked.append((path, type, id, event))
 
         numChecked += 1
 

--- a/examples/validate.py
+++ b/examples/validate.py
@@ -2,13 +2,13 @@
 
 # Copyright 2017 Ericsson AB.
 # For a full list of individual contributors, please see the commit history.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,175 +27,254 @@ import time
 import getopt
 from jsonschema import validate
 
+
 def extractArchives():
-  extractionPaths = []
-  for root, dirNames, fileNames in os.walk("."):
-    for fileName in fnmatch.filter(fileNames, "*.zip"):
-      archivePath = os.path.join(root, fileName)
-      extractionPath = os.path.join("examples", "".join(random.choice(string.ascii_lowercase) for i in range(16)))
-      extractionPaths.append(extractionPath)
-      print("Extracting " + archivePath + " to " + extractionPath + " ...", flush=True)
-      with zipfile.ZipFile(archivePath) as zf:
-        zf.extractall(extractionPath)
-  
-  return extractionPaths
-  
+    extractionPaths = []
+    for root, dirNames, fileNames in os.walk("."):
+        for fileName in fnmatch.filter(fileNames, "*.zip"):
+            archivePath = os.path.join(root, fileName)
+            extractionPath = os.path.join(
+                "examples",
+                "".join(
+                    random.choice(string.ascii_lowercase) for i in range(16)
+                ),
+            )
+            extractionPaths.append(extractionPath)
+            print(
+                "Extracting " + archivePath + " to " + extractionPath + " ...",
+                flush=True,
+            )
+            with zipfile.ZipFile(archivePath) as zf:
+                zf.extractall(extractionPath)
+
+    return extractionPaths
+
+
 def cleanExtractionPaths(extractionPaths):
-  for extractionPath in extractionPaths:
-    print("Deleting " + extractionPath + " ...", flush=True)
-    shutil.rmtree(extractionPath)
+    for extractionPath in extractionPaths:
+        print("Deleting " + extractionPath + " ...", flush=True)
+        shutil.rmtree(extractionPath)
+
 
 def loadAllJsonObjects(dir):
-  objects = []
-  badFiles = []
+    objects = []
+    badFiles = []
 
-  for root, dirNames, fileNames in os.walk(dir):
-    for fileName in fnmatch.filter(fileNames, "*.json"):
-      try:
-        path = os.path.join(root, fileName)
-        with open(path, "r") as f:
-          loadedObject = json.load(f)
-          if(isinstance(loadedObject, list)):
-            for o in loadedObject:
-              objects.append((path, fileName, o))
-          else:
-            objects.append((path, fileName, loadedObject))
-      except Exception as e:
-        print(e, flush=True)
-        badFiles.append(path)
-       
-  return objects, badFiles
-   
+    for root, dirNames, fileNames in os.walk(dir):
+        for fileName in fnmatch.filter(fileNames, "*.json"):
+            try:
+                path = os.path.join(root, fileName)
+                with open(path, "r") as f:
+                    loadedObject = json.load(f)
+                    if isinstance(loadedObject, list):
+                        for o in loadedObject:
+                            objects.append((path, fileName, o))
+                    else:
+                        objects.append((path, fileName, loadedObject))
+            except Exception as e:
+                print(e, flush=True)
+                badFiles.append(path)
+
+    return objects, badFiles
+
+
 def loadSchemas():
-  schemaTuples, badSchemaFiles = loadAllJsonObjects("schemas")
-  schemas = {}
-  for path, fileName, o in schemaTuples:
-    schemaName = os.path.basename(os.path.dirname(path))
-    versionName = fileName[:-5]
-    schemas[schemaName + "-" + versionName] = o
-  
-  return schemas, badSchemaFiles
-    
+    schemaTuples, badSchemaFiles = loadAllJsonObjects("schemas")
+    schemas = {}
+    for path, fileName, o in schemaTuples:
+        schemaName = os.path.basename(os.path.dirname(path))
+        versionName = fileName[:-5]
+        schemas[schemaName + "-" + versionName] = o
+
+    return schemas, badSchemaFiles
+
+
 def loadExamples():
-  exampleTuples, badExampleFiles = loadAllJsonObjects("examples")
-  examples = []
-  for path, fileName, o in exampleTuples:
-    examples.append((path, o["meta"]["type"], o["meta"]["version"], o["meta"]["id"], o))
+    exampleTuples, badExampleFiles = loadAllJsonObjects("examples")
+    examples = []
+    for path, fileName, o in exampleTuples:
+        examples.append(
+            (path, o["meta"]["type"], o["meta"]["version"], o["meta"]["id"], o)
+        )
 
-  return examples, badExampleFiles
-    
+    return examples, badExampleFiles
+
+
 def validateExamples(examples, schemas, maxExamples, shuffle):
-  failures = []
-  numberOfSuccessfulValidations = 0
-  unchecked = []
+    failures = []
+    numberOfSuccessfulValidations = 0
+    unchecked = []
 
-  numChecked = 0
-  latestReportTime = time.perf_counter()
-  
-  if shuffle:
-    random.shuffle(examples)
-  for path, type, version, id, json in examples:
-    schemaKey = type + "-" + version
-    if schemaKey in schemas:
-      try:
-        validate(json, schemas[schemaKey])
-        numberOfSuccessfulValidations += 1
-      except Exception as e:
-        failures.append((path, type, id, e))
-    else:
-      unchecked.append((path, type, id, json))
-    
-    numChecked += 1
-    
-    if maxExamples > 0 and numChecked >= maxExamples:
-      print("Reached limit of " + str(maxExamples) + " examples to validate. Breaking.")
-      break
-      
-    if time.perf_counter() - latestReportTime > 5:
-      print("Checked " + str(numChecked) + " / " + str(len(examples)) + " examples.", flush=True)
-      latestReportTime = time.perf_counter()
-      
-  return failures, unchecked, numberOfSuccessfulValidations
+    numChecked = 0
+    latestReportTime = time.perf_counter()
 
-def report(unchecked,failures,badSchemaFiles,badExampleFiles,numberOfSuccessfulValidations):
-  for path, type, id, o in unchecked:
-    print("ERROR: Missing schema for " + id + "(" + type + ") in " + path + ".", flush=True)
+    if shuffle:
+        random.shuffle(examples)
+    for path, type, version, id, json in examples:
+        schemaKey = type + "-" + version
+        if schemaKey in schemas:
+            try:
+                validate(json, schemas[schemaKey])
+                numberOfSuccessfulValidations += 1
+            except Exception as e:
+                failures.append((path, type, id, e))
+        else:
+            unchecked.append((path, type, id, json))
 
-  for badSchemaFile in badSchemaFiles:
-    print("ERROR: Failed to load schema from file", badSchemaFile, flush=True)
+        numChecked += 1
 
-  for badExampleFile in badExampleFiles:
-    print("ERROR: Failed to load example from file", badExampleFile, flush=True)
+        if maxExamples > 0 and numChecked >= maxExamples:
+            print(
+                "Reached limit of "
+                + str(maxExamples)
+                + " examples to validate. Breaking."
+            )
+            break
 
-  for path, type, id, e in failures:
-    print("ERROR: Validation failed for " + id + "(" + type + ") in " + path + ": " + str(e), flush=True)
-    
-  print("")
-  print("===SUMMARY===")
-  print("Bad schema files:        ", len(badSchemaFiles))
-  print("Bad example files:       ", len(badExampleFiles))
-  print("Successful validations:  ", numberOfSuccessfulValidations)
-  print("Failed validations:      ", len(failures))
-  print("Unchecked examples:      ", len(unchecked))
-  print("=============", flush=True)
- 
+        if time.perf_counter() - latestReportTime > 5:
+            print(
+                "Checked "
+                + str(numChecked)
+                + " / "
+                + str(len(examples))
+                + " examples.",
+                flush=True,
+            )
+            latestReportTime = time.perf_counter()
+
+    return failures, unchecked, numberOfSuccessfulValidations
+
+
+def report(
+    unchecked,
+    failures,
+    badSchemaFiles,
+    badExampleFiles,
+    numberOfSuccessfulValidations,
+):
+    for path, type, id, o in unchecked:
+        print(
+            "ERROR: Missing schema for "
+            + id
+            + "("
+            + type
+            + ") in "
+            + path
+            + ".",
+            flush=True,
+        )
+
+    for badSchemaFile in badSchemaFiles:
+        print(
+            "ERROR: Failed to load schema from file", badSchemaFile, flush=True
+        )
+
+    for badExampleFile in badExampleFiles:
+        print(
+            "ERROR: Failed to load example from file",
+            badExampleFile,
+            flush=True,
+        )
+
+    for path, type, id, e in failures:
+        print(
+            "ERROR: Validation failed for "
+            + id
+            + "("
+            + type
+            + ") in "
+            + path
+            + ": "
+            + str(e),
+            flush=True,
+        )
+
+    print("")
+    print("===SUMMARY===")
+    print("Bad schema files:        ", len(badSchemaFiles))
+    print("Bad example files:       ", len(badExampleFiles))
+    print("Successful validations:  ", numberOfSuccessfulValidations)
+    print("Failed validations:      ", len(failures))
+    print("Unchecked examples:      ", len(unchecked))
+    print("=============", flush=True)
+
+
 def main(maxExamples, includeArchives, shuffle):
-  if includeArchives:
-    extractionPaths = extractArchives()
+    if includeArchives:
+        extractionPaths = extractArchives()
 
-  schemas, badSchemaFiles = loadSchemas()
-  print("Loaded", len(schemas), "schemas.", flush=True)
+    schemas, badSchemaFiles = loadSchemas()
+    print("Loaded", len(schemas), "schemas.", flush=True)
 
-  examples, badExampleFiles = loadExamples()
-  print("Loaded", len(examples), "examples.", flush=True)
+    examples, badExampleFiles = loadExamples()
+    print("Loaded", len(examples), "examples.", flush=True)
 
-  failures, unchecked, numberOfSuccessfulValidations = validateExamples(examples, schemas, maxExamples, shuffle)
+    failures, unchecked, numberOfSuccessfulValidations = validateExamples(
+        examples, schemas, maxExamples, shuffle
+    )
 
-  if includeArchives:
-    cleanExtractionPaths(extractionPaths)
+    if includeArchives:
+        cleanExtractionPaths(extractionPaths)
 
-  report(unchecked, failures, badSchemaFiles, badExampleFiles, numberOfSuccessfulValidations)
+    report(
+        unchecked,
+        failures,
+        badSchemaFiles,
+        badExampleFiles,
+        numberOfSuccessfulValidations,
+    )
 
-  if (len(badSchemaFiles) + len(badExampleFiles) + len(failures) + len(unchecked)) > 0:
-    sys.exit("Validation failed.")
+    if (
+        len(badSchemaFiles)
+        + len(badExampleFiles)
+        + len(failures)
+        + len(unchecked)
+    ) > 0:
+        sys.exit("Validation failed.")
+
 
 def usage():
-  print("Usage:")
-  print("    This script will validate .json files in the examples directory.")
-  print("")
-  print("Arguments:")
-  print("    -m, --max-examples <number>")
-  print("        Limit the maximum number of examples to validate.")
-  print("    -a, --archives")
-  print("        Include any archives in the validation.")
-  print("        Any .zip in the examples directory will be unzipped,")
-  print("        and any .json in it included in the validation.")
-  print("    -s, --shuffle")
-  print("        Shuffle the list of examples to validate.")
-  print("        This is particularly useful when limiting the maximum")
-  print("        number of examples to validate.")
-  print("    -h, --help")
-  print("        Print this text.")
-  
+    print("Usage:")
+    print(
+        "    This script will validate .json files in the examples directory."
+    )
+    print("")
+    print("Arguments:")
+    print("    -m, --max-examples <number>")
+    print("        Limit the maximum number of examples to validate.")
+    print("    -a, --archives")
+    print("        Include any archives in the validation.")
+    print("        Any .zip in the examples directory will be unzipped,")
+    print("        and any .json in it included in the validation.")
+    print("    -s, --shuffle")
+    print("        Shuffle the list of examples to validate.")
+    print("        This is particularly useful when limiting the maximum")
+    print("        number of examples to validate.")
+    print("    -h, --help")
+    print("        Print this text.")
+
+
 maxExamples = 0
 includeArchives = False
 shuffle = False
 
 try:
-  opts, args = getopt.getopt(sys.argv[1:], "hm:as", ["help", "max-examples", "archives", "shuffle"])
+    opts, args = getopt.getopt(
+        sys.argv[1:], "hm:as", ["help", "max-examples", "archives", "shuffle"]
+    )
 except getopt.GetoptError:
-  usage()
-  sys.exit(1)
-    
-for opt, arg in opts:
-  if opt in ("-h", "--help"):
     usage()
-    sys.exit(0)
-  elif opt in ("-m", "--max-examples"):
-    maxExamples = int(arg)
-  elif opt in ("-a", "--archives"):
-    includeArchives = True
-  elif opt in ("-s", "--shuffle"):
-    shuffle = True
- 
+    sys.exit(1)
+
+for opt, arg in opts:
+    if opt in ("-h", "--help"):
+        usage()
+        sys.exit(0)
+    elif opt in ("-m", "--max-examples"):
+        maxExamples = int(arg)
+    elif opt in ("-a", "--archives"):
+        includeArchives = True
+    elif opt in ("-s", "--shuffle"):
+        shuffle = True
+
 main(maxExamples, includeArchives, shuffle)

--- a/find-latest-schemas.py
+++ b/find-latest-schemas.py
@@ -4,16 +4,20 @@ from shutil import copyfile
 import semver
 
 
-'''
+"""
 Finds the latest versions of schemas found under <input_folder>, with the following expectations:
 - Folder structure is <input_folder>/EVENT_NAME/VERSION.json
 - VERSION is semver compliant
 
 Copies the latest version of each event type as <output_folder>/EVENT_NAME.json
-'''
+"""
+
+
 def main():
     if len(sys.argv) != 3:
-        print("Usage: python {} input_folder output_folder".format(sys.argv[0]))
+        print(
+            "Usage: python {} input_folder output_folder".format(sys.argv[0])
+        )
         sys.exit(-1)
 
     input_folder = sys.argv[1]
@@ -27,14 +31,19 @@ def main():
         if len(files) != 0:
             latest_version = "0.0.0"
             for f in files:
-                latest_version = semver.max_ver(latest_version, os.path.splitext(f)[0])
-            latest_versions.append(os.path.join(base, latest_version + ".json"))
+                latest_version = semver.max_ver(
+                    latest_version, os.path.splitext(f)[0]
+                )
+            latest_versions.append(
+                os.path.join(base, latest_version + ".json")
+            )
 
     for f in latest_versions:
         new_name = os.path.split(os.path.dirname(f))[1] + ".json"
         output_file = os.path.join(output_folder, new_name)
         copyfile(f, output_file)
         print("{} => {}".format(f, output_file))
+
 
 if __name__ == "__main__":
     main()

--- a/find-latest-schemas.py
+++ b/find-latest-schemas.py
@@ -1,8 +1,8 @@
-import sys
 import os
+import sys
 from shutil import copyfile
-import semver
 
+import semver
 
 """
 Finds the latest versions of schemas found under <input_folder>, with

--- a/find-latest-schemas.py
+++ b/find-latest-schemas.py
@@ -16,9 +16,7 @@ Copies the latest version of each event type as <output_folder>/EVENT_NAME.json
 
 def main():
     if len(sys.argv) != 3:
-        print(
-            "Usage: python {} input_folder output_folder".format(sys.argv[0])
-        )
+        print("Usage: python {} input_folder output_folder".format(sys.argv[0]))
         sys.exit(-1)
 
     input_folder = sys.argv[1]
@@ -32,12 +30,8 @@ def main():
         if len(files) != 0:
             latest_version = "0.0.0"
             for f in files:
-                latest_version = semver.max_ver(
-                    latest_version, os.path.splitext(f)[0]
-                )
-            latest_versions.append(
-                os.path.join(base, latest_version + ".json")
-            )
+                latest_version = semver.max_ver(latest_version, os.path.splitext(f)[0])
+            latest_versions.append(os.path.join(base, latest_version + ".json"))
 
     for f in latest_versions:
         new_name = os.path.split(os.path.dirname(f))[1] + ".json"

--- a/find-latest-schemas.py
+++ b/find-latest-schemas.py
@@ -5,7 +5,8 @@ import semver
 
 
 """
-Finds the latest versions of schemas found under <input_folder>, with the following expectations:
+Finds the latest versions of schemas found under <input_folder>, with
+the following expectations:
 - Folder structure is <input_folder>/EVENT_NAME/VERSION.json
 - VERSION is semver compliant
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,0 @@
-[tool.black]
-line-length = 79

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 [tox]
-envlist = validate, black
+envlist = flake8, validate, black
 skip_missing_interpreters = True
 skipsdist = True
 
@@ -26,6 +26,17 @@ deps =
      black==21.12b0
 commands = black --check --diff .
 
+[testenv:flake8]
+deps =
+    flake8==4.0.1
+commands = flake8
+
 [testenv:validate]
 deps = -rrequirements.txt
 commands = python3 examples/validate.py
+
+[flake8]
+# Ignore a few formatting aspects that we let Black take care of.
+ignore =
+    E501
+    W503

--- a/tox.ini
+++ b/tox.ini
@@ -14,12 +14,17 @@
 # limitations under the License.
 
 [tox]
-envlist = validate
+envlist = validate, black
 skip_missing_interpreters = True
 skipsdist = True
 
 [testenv]
 basepython = python3
+
+[testenv:black]
+deps =
+     black==21.12b0
+commands = black --check --diff .
 
 [testenv:validate]
 deps = -rrequirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 [tox]
-envlist = flake8, validate, black
+envlist = flake8, validate, black, isort
 skip_missing_interpreters = True
 skipsdist = True
 
@@ -31,6 +31,11 @@ deps =
     flake8==4.0.1
 commands = flake8
 
+[testenv:isort]
+deps =
+    isort==5.10.1
+commands = isort --check-only --diff .
+
 [testenv:validate]
 deps = -rrequirements.txt
 commands = python3 examples/validate.py
@@ -40,3 +45,7 @@ commands = python3 examples/validate.py
 ignore =
     E501
     W503
+
+[isort]
+atomic = True
+force_single_line = True


### PR DESCRIPTION
### Applicable Issues
Fixes #291 

### Description of the Change
We add three commonly used linters and code formatters; [Black](https://black.readthedocs.io/en/stable/index.html), [flake8](https://flake8.pycqa.org/en/latest/), and [isort](https://github.com/PyCQA/isort). Together they make sure all Python code is consistently formatted and has a reasonably consistent style in other aspects. All code has been adjusted to satisfy these program. This has been in one commit per linter so I recommend the PR is reviewed commit by commit.

Note that the commit that introduces Black doesn't use its default line length of 88 characters but rather the more traditional limit of 79 characters. This resulted in a number of odd linebreaks so I added an extra commit at that top of the stack that flipped to Black's default. That resulted in fewer linebreaks and is arguably an improvement. I personally don't mind a line length limit higher than 80 characters but if that's what you prefer I can just chop off the last commit. See [Black's rationale for its 88 character limit](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#line-length) for some background.

### Alternate Designs
None, but see line length discussion above.

### Benefits
Easier for developers to produce consistent code. Less work for reviewers.

### Possible Drawbacks
None, unless you have very particular opinions about code style and formatting.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
