### PR TITLE
tox: Upgrade Black dependency to fix Click incompatibility

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ basepython = python3
 
 [testenv:black]
 deps =
-     black==21.12b0
+     black==22.6.0
 commands = black --check --diff .
 
 [testenv:flake8]


### PR DESCRIPTION
### Applicable Issues
Fixes #307

### Description of the Change
Black depends on Click and seems to have use a non-public API. When Click changed their API this broke Black, resulting in the following error when running Black:

    ImportError: cannot import name '_unicodefun' from 'click' (...)

Upgrading Black to the most recent release addresses the problem. We should be using Poetry to lock all transitive dependencies and avoid this class of problems in the future.

### Alternate Designs
We could've gone straight for Poetry to make sure similar problems don't pop up, but I opted for fixing the immediate problem quickly so that we have working CI. We already have a couple of open PRs that've had to upgrade Black to get the checks to pass.

### Benefits
Working tox execution.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
