### PR TITLE
SCS: Fix incorrect docs for data.ccCompositeIdentifier.vobs

### DIFF
--- a/eiffel-vocabulary/EiffelSourceChangeSubmittedEvent.md
+++ b/eiffel-vocabulary/EiffelSourceChangeSubmittedEvent.md
@@ -103,7 +103,7 @@ __Type:__ Object
 __Required:__ No  
 __Description:__ Identifier of a composite ClearCase change – in other words, not single file commit, but analogous of repository-wide commits of e.g. SVN or Git.
 
-#### data.ccCompositeIdentifier.vob
+#### data.ccCompositeIdentifier.vobs
 __Type:__ String[]  
 __Required:__ Yes  
 __Description:__ The names of the changed ClearCase VOBs.


### PR DESCRIPTION
### Applicable Issues
Fixes #306 

### Description of the Change
The SCS event has a data.ccCompositeIdentifier.vobs member listed in the schema but the documentation calls it data.ccCompositeIdentifier.vob, i.e. singular instead of plural. Fixing this buglet.

### Alternate Designs
None.

### Benefits
Fewer inconsistencies, less confusion.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
