### PR TITLE
Define five additional names of future Eiffel editions

### DIFF
--- a/eiffel-syntax-and-usage/versioning.md
+++ b/eiffel-syntax-and-usage/versioning.md
@@ -26,6 +26,11 @@ That being said, to facilitate compatibility and consistency, the Eiffel protoco
 
 | Edition   | Tag                                                 | Changes                                          |
 | --------- | --------------------------------------------------- | ------------------------------------------------ |
+| Tacna  | _Reserved for future use._  | |
+| Budapest  | _Reserved for future use._  | |
+| Ruhnu  | _Reserved for future use._  | |
+| Santiago  | _Reserved for future use._  | |
+| Orizaba  | _Reserved for future use._  | |
 | Arica  | _Reserved for future use._  | |
 | Lyon  | [edition-lyon](../../../tree/edition-lyon)  | Added domainId member to links ([Issue 233](https://github.com/eiffel-community/eiffel/issues/233)), added {mediaType,tags} to data.{liveLogs,persistentLogs} of various event types ([Issue 166](https://github.com/eiffel-community/eiffel/issues/166)), added RUNTIME_ENVIRONMENT as link type for ED ([Issue 258](https://github.com/eiffel-community/eiffel/issues/258)), and added missing validation pattern for links.target of TERCC ([Issue 271](https://github.com/eiffel-community/eiffel/issues/271)). |
 | Paris  | [edition-paris](../../../tree/edition-paris)  | Minor backwards-compatible changes to CD and ArtP (Issues [218](https://github.com/eiffel-community/eiffel/issues/218) and [248](https://github.com/eiffel-community/eiffel/issues/248)). |


### PR DESCRIPTION
### Applicable Issues
Fixes #300

### Description of the Change
After the upcoming Arica edition no more editions have been named, making it harder to plan for and reason about future editions. With the help of https://en.wikipedia.org/wiki/Gustave_Eiffel five additional cities where Gustave Eiffel has made contributions have bene identified and listed in the documentation.

### Alternate Designs
None.

### Benefits
Easier to plan and reason about future editions if they're given names.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
