### PR TITLE
Replace outdated references to https://github.com/Ericsson/eiffel

### DIFF
--- a/customization/custom-data.md
+++ b/customization/custom-data.md
@@ -25,7 +25,7 @@ __data.customData__ is an optional member of _all_ Eiffel events. It is an array
 While __data.customData__ affords users extensive freedom in including custom content, they are strongly encouraged to consider the following before making use of it:
 
 * Are there existing Eiffel events and/or event members able to express the information? Using the standard vocabulary and syntax should always be the first option.
-* If your use case lacks support in the standard Eiffel vocabulary, there's a chance this is actually a general use case which deserves such support. Create an [Issue](https://github.com/Ericsson/eiffel/issues) about it! It is always better to design a common solution than to implement multiple local adaptations.
+* If your use case lacks support in the standard Eiffel vocabulary, there's a chance this is actually a general use case which deserves such support. Create an [Issue](https://github.com/eiffel-community/eiffel/issues) about it! It is always better to design a common solution than to implement multiple local adaptations.
 * Users defining __data.customData__ members are responsible for them and any compatibility issues. Special considerations or support from standard Eiffel events or syntax can not be expected, unless the custom syntax is proposed to and accepted into the standard Eiffel vocabulary (and consequently is no longer custom).
 
 The [event design guidelines](../eiffel-syntax-and-usage/event-design-guidelines.md) shall be observed with regards to key and value naming conventions.

--- a/customization/custom-events.md
+++ b/customization/custom-events.md
@@ -16,12 +16,12 @@
 --->
 
 # Custom Events
-Eiffel offers a rich vocabulary designed to cover the vast majority of continuous integration and delivery use cases. Situations may arise where the defined events are not sufficient, however. In such circumstances, users are encouraged to spawn a discussion by [creating an Issue in the Eiffel repository](https://github.com/Ericsson/eiffel/issues) - perhaps the existing vocabulary can be used, or perhaps the new use case warrants changes to the Eiffel event definitions.
+Eiffel offers a rich vocabulary designed to cover the vast majority of continuous integration and delivery use cases. Situations may arise where the defined events are not sufficient, however. In such circumstances, users are encouraged to spawn a discussion by [creating an Issue in the Eiffel repository](https://github.com/eiffel-community/eiffel/issues) - perhaps the existing vocabulary can be used, or perhaps the new use case warrants changes to the Eiffel event definitions.
 
 That being said, users are free to send custom complementary events in parallel with Eiffel events. These events can be defined similarly to the standard vocabulary and may use __links__ to reference the standard Eiffel events. When defining such custom events, however, there are a few rules of conduct that users are strongly encouraged to observe:
 
 * Custom events are not allowed masquerade as standard Eiffel events, and shall therefore not be prefixed "Eiffel". To exemplify, a recommended custom event name would be "MyCustomEvent", but not "EiffelMyCustomEvent".
-* Use [Issues](https://github.com/Ericsson/eiffel/issues) and [Pull requests](https://github.com/Ericsson/eiffel/pulls) to stay in touch with the community to discuss why and how you define custom events. Others may find them useful, too!
+* Use [Issues](https://github.com/eiffel-community/eiffel/issues) and [Pull requests](https://github.com/eiffel-community/eiffel/pulls) to stay in touch with the community to discuss why and how you define custom events. Others may find them useful, too!
 * Follow the [event design guidelines](../eiffel-syntax-and-usage/event-design-guidelines.md).
 * Consider whether your need can be addressed by __data.customData__.
 * Users defining custom events are responsible for them and any compatibility issues. Special considerations or support from standard Eiffel events can not be expected, unless the custom events are proposed to and accepted into the standard Eiffel vocabulary (and consequently are no longer custom).

--- a/eiffel-syntax-and-usage/versioning.md
+++ b/eiffel-syntax-and-usage/versioning.md
@@ -22,7 +22,7 @@ The independent versioning of event types, as opposed to a protocol-wide version
 * Consumers must always be ready to receive event types which they are unable to parse: the event producer may be ahead of the consumer on one event type, but not another. Similarly, new and/or custom event types must be expected and handled.
 * Backwards incompatible changes may not be introduced to the __meta.type__ and __meta.version__ properties, as these together form the key which allows the consumer to unlock the remainder of the event.
 
-That being said, to facilitate compatibility and consistency, the Eiffel protocol as described in this repository is released in named and internally coherent _editions_. Each of these editions is represented as a GitHub [release](https://github.com/Ericsson/eiffel/releases). A history of Eiffel editions is available below.
+That being said, to facilitate compatibility and consistency, the Eiffel protocol as described in this repository is released in named and internally coherent _editions_. Each of these editions is represented as a GitHub [release](https://github.com/eiffel-community/eiffel/releases). A history of Eiffel editions is available below.
 
 | Edition   | Tag                                                 | Changes                                          |
 | --------- | --------------------------------------------------- | ------------------------------------------------ |


### PR DESCRIPTION
### Applicable Issues
Fixes #316 

### Description of the Change
The documentation contains a few links to https://github.com/Ericsson/eiffel, i.e. the previous home of the Eiffel protocol. The old repository URL redirects to the current URL (for now anyway), but the documentation should nevertheless be correct.

### Alternate Designs
None.

### Benefits
Decreased risk of spreading outdated URLs.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
