### PR TITLE
Add test that verifies history tables entries

### DIFF
--- a/definitions/EiffelTestCaseFinishedEvent/1.0.0.yml
+++ b/definitions/EiffelTestCaseFinishedEvent/1.0.0.yml
@@ -118,5 +118,8 @@ required:
   - links
 additionalProperties: false
 _links: {}
-_history: []
+_history:
+  - version: 1.0.0
+    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    changes: Initial version.
 _examples: []

--- a/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/1.0.0.yml
+++ b/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/1.0.0.yml
@@ -181,5 +181,8 @@ required:
   - links
 additionalProperties: false
 _links: {}
-_history: []
+_history:
+  - version: 1.0.0
+    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    changes: Initial version.
 _examples: []

--- a/test_definitions.py
+++ b/test_definitions.py
@@ -1,0 +1,35 @@
+# Copyright 2023 Axis Communications AB.
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pathlib
+
+import pytest
+
+import definition_loader
+
+
+@pytest.mark.parametrize(
+    "event_definition_path",
+    pathlib.Path(".").glob("definitions/Eiffel*Event/*.yml"),
+)
+def test_history_table_contains_current_version(event_definition_path):
+    definition = definition_loader.load(event_definition_path)
+    event_type = event_definition_path.parent.name
+    event_version = event_definition_path.stem
+    assert [
+        entry
+        for entry in definition.get("_history", [])
+        if entry.get("version") == event_version
+    ], f"History table entry missing for {event_type} {event_version}"


### PR DESCRIPTION
### Applicable Issues
Fixes #351 

### Description of the Change
It's easy to forget to add an entry in the history table when you copy an existing event definition file. We therefore add a Python test file with a short test that verifies that each event definition has a corresponding history table entry.

The new test exposed to definition files without history tables so we had to correct them too.

### Alternate Designs
I considered adding the check in generate_docs.py instead, thus making it part of the documentation generation. However, that would make it harder to experiment and play around with the definition files.

### Benefits
Will catch mistakes so a human won't have to.

### Possible Drawbacks
Adds ~4 s to the tox execution time.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
