### PR TITLE
Change definition of "introduced_in" field in the history tables

### DIFF
--- a/definitions/EiffelActivityCanceledEvent/1.0.0.yml
+++ b/definitions/EiffelActivityCanceledEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelActivityCanceledEvent/1.0.0.yml
+++ b/definitions/EiffelActivityCanceledEvent/1.0.0.yml
@@ -95,7 +95,7 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelActivityCanceledEvent/1.1.0.yml
+++ b/definitions/EiffelActivityCanceledEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelActivityCanceledEvent/1.1.0.yml
+++ b/definitions/EiffelActivityCanceledEvent/1.1.0.yml
@@ -95,10 +95,10 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelActivityCanceledEvent/2.0.0.yml
+++ b/definitions/EiffelActivityCanceledEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelActivityCanceledEvent/2.0.0.yml
+++ b/definitions/EiffelActivityCanceledEvent/2.0.0.yml
@@ -95,14 +95,14 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 2.0.0
-    introduced_in: Current version
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelActivityCanceledEvent/3.0.0.yml
+++ b/definitions/EiffelActivityCanceledEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelActivityCanceledEvent/3.0.0.yml
+++ b/definitions/EiffelActivityCanceledEvent/3.0.0.yml
@@ -95,17 +95,17 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelActivityCanceledEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelActivityCanceledEvent/3.1.0.yml
+++ b/definitions/EiffelActivityCanceledEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelActivityCanceledEvent/3.1.0.yml
+++ b/definitions/EiffelActivityCanceledEvent/3.1.0.yml
@@ -95,21 +95,21 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 3.1.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelActivityCanceledEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelActivityCanceledEvent/3.2.0.yml
+++ b/definitions/EiffelActivityCanceledEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelActivityCanceledEvent/3.2.0.yml
+++ b/definitions/EiffelActivityCanceledEvent/3.2.0.yml
@@ -95,24 +95,24 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 3.2.0
-    introduced_in: '[edition-arica](../../../tree/edition-arica)'
+    introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
   - version: 3.1.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelActivityCanceledEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelActivityFinishedEvent/1.0.0.yml
+++ b/definitions/EiffelActivityFinishedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelActivityFinishedEvent/1.0.0.yml
+++ b/definitions/EiffelActivityFinishedEvent/1.0.0.yml
@@ -136,7 +136,7 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelActivityFinishedEvent/1.1.0.yml
+++ b/definitions/EiffelActivityFinishedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelActivityFinishedEvent/1.1.0.yml
+++ b/definitions/EiffelActivityFinishedEvent/1.1.0.yml
@@ -136,10 +136,10 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelActivityFinishedEvent/2.0.0.yml
+++ b/definitions/EiffelActivityFinishedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelActivityFinishedEvent/2.0.0.yml
+++ b/definitions/EiffelActivityFinishedEvent/2.0.0.yml
@@ -136,14 +136,14 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 2.0.0
-    introduced_in: Current version
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelActivityFinishedEvent/3.0.0.yml
+++ b/definitions/EiffelActivityFinishedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelActivityFinishedEvent/3.0.0.yml
+++ b/definitions/EiffelActivityFinishedEvent/3.0.0.yml
@@ -136,17 +136,17 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelActivityFinishedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelActivityFinishedEvent/3.1.0.yml
+++ b/definitions/EiffelActivityFinishedEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelActivityFinishedEvent/3.1.0.yml
+++ b/definitions/EiffelActivityFinishedEvent/3.1.0.yml
@@ -149,20 +149,20 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 3.1.0
-    introduced_in: Current version
+    introduced_in: edition-lyon
     changes: Add `data.persistentLogs.{mediaType,tags}`.
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelActivityFinishedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelActivityFinishedEvent/3.2.0.yml
+++ b/definitions/EiffelActivityFinishedEvent/3.2.0.yml
@@ -149,24 +149,24 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 3.2.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.1.0
-    introduced_in: No edition set
+    introduced_in: edition-lyon
     changes: Add `data.persistentLogs.{mediaType,tags}`.
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelActivityFinishedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelActivityFinishedEvent/3.2.0.yml
+++ b/definitions/EiffelActivityFinishedEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelActivityFinishedEvent/3.3.0.yml
+++ b/definitions/EiffelActivityFinishedEvent/3.3.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelActivityFinishedEvent/3.3.0.yml
+++ b/definitions/EiffelActivityFinishedEvent/3.3.0.yml
@@ -149,27 +149,27 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 3.3.0
-    introduced_in: '[edition-arica](../../../tree/edition-arica)'
+    introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
   - version: 3.2.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.1.0
-    introduced_in: No edition set
+    introduced_in: edition-lyon
     changes: Add `data.persistentLogs.{mediaType,tags}`.
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelActivityFinishedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelActivityStartedEvent/1.0.0.yml
+++ b/definitions/EiffelActivityStartedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelActivityStartedEvent/1.0.0.yml
+++ b/definitions/EiffelActivityStartedEvent/1.0.0.yml
@@ -122,7 +122,7 @@ _links:
         - EiffelActivityTriggeredEvent
 _history:
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelActivityStartedEvent/1.1.0.yml
+++ b/definitions/EiffelActivityStartedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelActivityStartedEvent/1.1.0.yml
+++ b/definitions/EiffelActivityStartedEvent/1.1.0.yml
@@ -122,10 +122,10 @@ _links:
         - EiffelActivityTriggeredEvent
 _history:
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelActivityStartedEvent/2.0.0.yml
+++ b/definitions/EiffelActivityStartedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelActivityStartedEvent/2.0.0.yml
+++ b/definitions/EiffelActivityStartedEvent/2.0.0.yml
@@ -122,14 +122,14 @@ _links:
         - EiffelActivityTriggeredEvent
 _history:
   - version: 2.0.0
-    introduced_in: Current version
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelActivityStartedEvent/3.0.0.yml
+++ b/definitions/EiffelActivityStartedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelActivityStartedEvent/3.0.0.yml
+++ b/definitions/EiffelActivityStartedEvent/3.0.0.yml
@@ -122,17 +122,17 @@ _links:
         - EiffelActivityTriggeredEvent
 _history:
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelActivityStartedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelActivityStartedEvent/4.0.0.yml
+++ b/definitions/EiffelActivityStartedEvent/4.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelActivityStartedEvent/4.0.0.yml
+++ b/definitions/EiffelActivityStartedEvent/4.0.0.yml
@@ -122,21 +122,21 @@ _links:
         - EiffelActivityTriggeredEvent
 _history:
   - version: 4.0.0
-    introduced_in: '[edition-agen-1](../../../tree/edition-agen-1)'
+    introduced_in: edition-agen-1
     changes: Bug fix in schema file (see [Issue 205](https://github.com/eiffel-community/eiffel/issues/205))
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185))
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelActivityStartedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelActivityStartedEvent/4.1.0.yml
+++ b/definitions/EiffelActivityStartedEvent/4.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelActivityStartedEvent/4.1.0.yml
+++ b/definitions/EiffelActivityStartedEvent/4.1.0.yml
@@ -135,24 +135,24 @@ _links:
         - EiffelActivityTriggeredEvent
 _history:
   - version: 4.1.0
-    introduced_in: Current version
+    introduced_in: edition-lyon
     changes: Add `data.liveLogs.{mediaType,tags}`.
   - version: 4.0.0
-    introduced_in: '[edition-agen-1](../../../tree/edition-agen-1)'
+    introduced_in: edition-agen-1
     changes: Bug fix in schema file (see [Issue 205](https://github.com/eiffel-community/eiffel/issues/205))
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185))
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelActivityStartedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelActivityStartedEvent/4.2.0.yml
+++ b/definitions/EiffelActivityStartedEvent/4.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelActivityStartedEvent/4.2.0.yml
+++ b/definitions/EiffelActivityStartedEvent/4.2.0.yml
@@ -135,27 +135,27 @@ _links:
         - EiffelActivityTriggeredEvent
 _history:
   - version: 4.2.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 4.1.0
-    introduced_in: No edition set
+    introduced_in: edition-lyon
     changes: Add `data.liveLogs.{mediaType,tags}`.
   - version: 4.0.0
-    introduced_in: '[edition-agen-1](../../../tree/edition-agen-1)'
+    introduced_in: edition-agen-1
     changes: Bug fix in schema file (see [Issue 205](https://github.com/eiffel-community/eiffel/issues/205))
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185))
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelActivityStartedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelActivityStartedEvent/4.3.0.yml
+++ b/definitions/EiffelActivityStartedEvent/4.3.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelActivityStartedEvent/4.3.0.yml
+++ b/definitions/EiffelActivityStartedEvent/4.3.0.yml
@@ -135,30 +135,30 @@ _links:
         - EiffelActivityTriggeredEvent
 _history:
   - version: 4.3.0
-    introduced_in: '[edition-arica](../../../tree/edition-arica)'
+    introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
   - version: 4.2.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 4.1.0
-    introduced_in: No edition set
+    introduced_in: edition-lyon
     changes: Add `data.liveLogs.{mediaType,tags}`.
   - version: 4.0.0
-    introduced_in: '[edition-agen-1](../../../tree/edition-agen-1)'
+    introduced_in: edition-agen-1
     changes: Bug fix in schema file (see [Issue 205](https://github.com/eiffel-community/eiffel/issues/205))
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185))
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelActivityStartedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelActivityTriggeredEvent/1.0.0.yml
+++ b/definitions/EiffelActivityTriggeredEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelActivityTriggeredEvent/1.0.0.yml
+++ b/definitions/EiffelActivityTriggeredEvent/1.0.0.yml
@@ -127,7 +127,7 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelActivityTriggeredEvent/1.1.0.yml
+++ b/definitions/EiffelActivityTriggeredEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelActivityTriggeredEvent/1.1.0.yml
+++ b/definitions/EiffelActivityTriggeredEvent/1.1.0.yml
@@ -127,10 +127,10 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelActivityTriggeredEvent/2.0.0.yml
+++ b/definitions/EiffelActivityTriggeredEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelActivityTriggeredEvent/2.0.0.yml
+++ b/definitions/EiffelActivityTriggeredEvent/2.0.0.yml
@@ -127,14 +127,14 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 2.0.0
-    introduced_in: Current version
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelActivityTriggeredEvent/3.0.0.yml
+++ b/definitions/EiffelActivityTriggeredEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelActivityTriggeredEvent/3.0.0.yml
+++ b/definitions/EiffelActivityTriggeredEvent/3.0.0.yml
@@ -127,17 +127,17 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelActivityTriggeredEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelActivityTriggeredEvent/4.0.0.yml
+++ b/definitions/EiffelActivityTriggeredEvent/4.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelActivityTriggeredEvent/4.0.0.yml
+++ b/definitions/EiffelActivityTriggeredEvent/4.0.0.yml
@@ -127,21 +127,21 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 4.0.0
-    introduced_in: '[edition-agen-1](../../../tree/edition-agen-1)'
+    introduced_in: edition-agen-1
     changes: Bug fix in schema file (see [Issue 205](https://github.com/eiffel-community/eiffel/issues/205))
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185))
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelActivityTriggeredEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelActivityTriggeredEvent/4.1.0.yml
+++ b/definitions/EiffelActivityTriggeredEvent/4.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelActivityTriggeredEvent/4.1.0.yml
+++ b/definitions/EiffelActivityTriggeredEvent/4.1.0.yml
@@ -142,24 +142,24 @@ _links:
         - EiffelActivityTriggeredEvent
 _history:
   - version: 4.1.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 4.0.0
-    introduced_in: '[edition-agen-1](../../../tree/edition-agen-1)'
+    introduced_in: edition-agen-1
     changes: Bug fix in schema file (see [Issue 205](https://github.com/eiffel-community/eiffel/issues/205))
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185))
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelActivityTriggeredEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelActivityTriggeredEvent/4.2.0.yml
+++ b/definitions/EiffelActivityTriggeredEvent/4.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelActivityTriggeredEvent/4.2.0.yml
+++ b/definitions/EiffelActivityTriggeredEvent/4.2.0.yml
@@ -142,27 +142,27 @@ _links:
         - EiffelActivityTriggeredEvent
 _history:
   - version: 4.2.0
-    introduced_in: '[edition-arica](../../../tree/edition-arica)'
+    introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
   - version: 4.1.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 4.0.0
-    introduced_in: '[edition-agen-1](../../../tree/edition-agen-1)'
+    introduced_in: edition-agen-1
     changes: Bug fix in schema file (see [Issue 205](https://github.com/eiffel-community/eiffel/issues/205))
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185))
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelActivityTriggeredEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelAnnouncementPublishedEvent/1.0.0.yml
+++ b/definitions/EiffelAnnouncementPublishedEvent/1.0.0.yml
@@ -113,7 +113,7 @@ _links:
         - EiffelAnnouncementPublishedEvent
 _history:
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelAnnouncementPublishedEvent/1.0.0.yml
+++ b/definitions/EiffelAnnouncementPublishedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelAnnouncementPublishedEvent/1.1.0.yml
+++ b/definitions/EiffelAnnouncementPublishedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelAnnouncementPublishedEvent/1.1.0.yml
+++ b/definitions/EiffelAnnouncementPublishedEvent/1.1.0.yml
@@ -113,10 +113,10 @@ _links:
         - EiffelAnnouncementPublishedEvent
 _history:
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelAnnouncementPublishedEvent/2.0.0.yml
+++ b/definitions/EiffelAnnouncementPublishedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelAnnouncementPublishedEvent/2.0.0.yml
+++ b/definitions/EiffelAnnouncementPublishedEvent/2.0.0.yml
@@ -113,14 +113,14 @@ _links:
         - EiffelAnnouncementPublishedEvent
 _history:
   - version: 2.0.0
-    introduced_in: Current version
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelAnnouncementPublishedEvent/3.0.0.yml
+++ b/definitions/EiffelAnnouncementPublishedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelAnnouncementPublishedEvent/3.0.0.yml
+++ b/definitions/EiffelAnnouncementPublishedEvent/3.0.0.yml
@@ -113,17 +113,17 @@ _links:
         - EiffelAnnouncementPublishedEvent
 _history:
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelAnnouncementPublishedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelAnnouncementPublishedEvent/3.1.0.yml
+++ b/definitions/EiffelAnnouncementPublishedEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelAnnouncementPublishedEvent/3.1.0.yml
+++ b/definitions/EiffelAnnouncementPublishedEvent/3.1.0.yml
@@ -113,21 +113,21 @@ _links:
         - EiffelAnnouncementPublishedEvent
 _history:
   - version: 3.1.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelAnnouncementPublishedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelAnnouncementPublishedEvent/3.2.0.yml
+++ b/definitions/EiffelAnnouncementPublishedEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelAnnouncementPublishedEvent/3.2.0.yml
+++ b/definitions/EiffelAnnouncementPublishedEvent/3.2.0.yml
@@ -113,24 +113,24 @@ _links:
         - EiffelAnnouncementPublishedEvent
 _history:
   - version: 3.2.0
-    introduced_in: '[edition-arica](../../../tree/edition-arica)'
+    introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
   - version: 3.1.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelAnnouncementPublishedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelArtifactCreatedEvent/1.0.0.yml
+++ b/definitions/EiffelArtifactCreatedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelArtifactCreatedEvent/1.0.0.yml
+++ b/definitions/EiffelArtifactCreatedEvent/1.0.0.yml
@@ -211,7 +211,7 @@ _links:
         - EiffelArtifactCreatedEvent
 _history:
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelArtifactCreatedEvent/1.1.0.yml
+++ b/definitions/EiffelArtifactCreatedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelArtifactCreatedEvent/1.1.0.yml
+++ b/definitions/EiffelArtifactCreatedEvent/1.1.0.yml
@@ -211,10 +211,10 @@ _links:
         - EiffelArtifactCreatedEvent
 _history:
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelArtifactCreatedEvent/2.0.0.yml
+++ b/definitions/EiffelArtifactCreatedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelArtifactCreatedEvent/2.0.0.yml
+++ b/definitions/EiffelArtifactCreatedEvent/2.0.0.yml
@@ -184,14 +184,14 @@ _links:
         - EiffelArtifactCreatedEvent
 _history:
   - version: 2.0.0
-    introduced_in: Current version
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelArtifactCreatedEvent/3.0.0.yml
+++ b/definitions/EiffelArtifactCreatedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelArtifactCreatedEvent/3.0.0.yml
+++ b/definitions/EiffelArtifactCreatedEvent/3.0.0.yml
@@ -184,17 +184,17 @@ _links:
         - EiffelArtifactCreatedEvent
 _history:
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelArtifactCreatedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelArtifactCreatedEvent/3.1.0.yml
+++ b/definitions/EiffelArtifactCreatedEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelArtifactCreatedEvent/3.1.0.yml
+++ b/definitions/EiffelArtifactCreatedEvent/3.1.0.yml
@@ -184,21 +184,21 @@ _links:
         - EiffelArtifactCreatedEvent
 _history:
   - version: 3.1.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelArtifactCreatedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelArtifactCreatedEvent/3.2.0.yml
+++ b/definitions/EiffelArtifactCreatedEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelArtifactCreatedEvent/3.2.0.yml
+++ b/definitions/EiffelArtifactCreatedEvent/3.2.0.yml
@@ -184,24 +184,24 @@ _links:
         - EiffelArtifactCreatedEvent
 _history:
   - version: 3.2.0
-    introduced_in: 'No edition set'
+    introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
   - version: 3.1.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelArtifactCreatedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelArtifactCreatedEvent/3.3.0.yml
+++ b/definitions/EiffelArtifactCreatedEvent/3.3.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelArtifactCreatedEvent/3.3.0.yml
+++ b/definitions/EiffelArtifactCreatedEvent/3.3.0.yml
@@ -213,27 +213,27 @@ _links:
         - EiffelArtifactCreatedEvent
 _history:
   - version: 3.3.0
-    introduced_in: '[edition-arica](../../../tree/edition-arica)'
+    introduced_in: edition-arica
     changes: Added data.fileInformation.integrityProtection member (see [Issue 290](https://github.com/eiffel-community/eiffel/issues/290)).
   - version: 3.2.0
-    introduced_in: 'No edition set'
+    introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
   - version: 3.1.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelArtifactCreatedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelArtifactDeployedEvent/0.1.0.yml
+++ b/definitions/EiffelArtifactDeployedEvent/0.1.0.yml
@@ -113,7 +113,6 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 0.1.0
-    introduced_in: No edition set
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelArtifactPublishedEvent/1.0.0.yml
+++ b/definitions/EiffelArtifactPublishedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelArtifactPublishedEvent/1.0.0.yml
+++ b/definitions/EiffelArtifactPublishedEvent/1.0.0.yml
@@ -112,7 +112,7 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelArtifactPublishedEvent/1.1.0.yml
+++ b/definitions/EiffelArtifactPublishedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelArtifactPublishedEvent/1.1.0.yml
+++ b/definitions/EiffelArtifactPublishedEvent/1.1.0.yml
@@ -112,10 +112,10 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelArtifactPublishedEvent/2.0.0.yml
+++ b/definitions/EiffelArtifactPublishedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelArtifactPublishedEvent/2.0.0.yml
+++ b/definitions/EiffelArtifactPublishedEvent/2.0.0.yml
@@ -112,14 +112,14 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 2.0.0
-    introduced_in: Current version
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelArtifactPublishedEvent/3.0.0.yml
+++ b/definitions/EiffelArtifactPublishedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelArtifactPublishedEvent/3.0.0.yml
+++ b/definitions/EiffelArtifactPublishedEvent/3.0.0.yml
@@ -112,17 +112,17 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelArtifactPublishedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelArtifactPublishedEvent/3.1.0.yml
+++ b/definitions/EiffelArtifactPublishedEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelArtifactPublishedEvent/3.1.0.yml
+++ b/definitions/EiffelArtifactPublishedEvent/3.1.0.yml
@@ -119,21 +119,21 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 3.1.0
-    introduced_in: '[edition-paris](../../../tree/edition-paris)'
+    introduced_in: edition-paris
     changes: Added name qualifier for artifact locations (see [Issue
       248](https://github.com/eiffel-community/eiffel/issues/248))
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelArtifactPublishedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelArtifactPublishedEvent/3.2.0.yml
+++ b/definitions/EiffelArtifactPublishedEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelArtifactPublishedEvent/3.2.0.yml
+++ b/definitions/EiffelArtifactPublishedEvent/3.2.0.yml
@@ -119,25 +119,25 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 3.2.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.1.0
-    introduced_in: '[edition-paris](../../../tree/edition-paris)'
+    introduced_in: edition-paris
     changes: Added name qualifier for artifact locations (see [Issue
       248](https://github.com/eiffel-community/eiffel/issues/248))
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelArtifactPublishedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelArtifactPublishedEvent/3.3.0.yml
+++ b/definitions/EiffelArtifactPublishedEvent/3.3.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelArtifactPublishedEvent/3.3.0.yml
+++ b/definitions/EiffelArtifactPublishedEvent/3.3.0.yml
@@ -119,28 +119,28 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 3.3.0
-    introduced_in: '[edition-arica](../../../tree/edition-arica)'
+    introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
   - version: 3.2.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.1.0
-    introduced_in: '[edition-paris](../../../tree/edition-paris)'
+    introduced_in: edition-paris
     changes: Added name qualifier for artifact locations (see [Issue
       248](https://github.com/eiffel-community/eiffel/issues/248))
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelArtifactPublishedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelArtifactReusedEvent/1.0.0.yml
+++ b/definitions/EiffelArtifactReusedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelArtifactReusedEvent/1.0.0.yml
+++ b/definitions/EiffelArtifactReusedEvent/1.0.0.yml
@@ -94,7 +94,7 @@ _links:
         - EiffelArtifactCreatedEvent
 _history:
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelArtifactReusedEvent/1.1.0.yml
+++ b/definitions/EiffelArtifactReusedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelArtifactReusedEvent/1.1.0.yml
+++ b/definitions/EiffelArtifactReusedEvent/1.1.0.yml
@@ -94,10 +94,10 @@ _links:
         - EiffelArtifactCreatedEvent
 _history:
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelArtifactReusedEvent/2.0.0.yml
+++ b/definitions/EiffelArtifactReusedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelArtifactReusedEvent/2.0.0.yml
+++ b/definitions/EiffelArtifactReusedEvent/2.0.0.yml
@@ -94,14 +94,14 @@ _links:
         - EiffelArtifactCreatedEvent
 _history:
   - version: 2.0.0
-    introduced_in: Current version
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelArtifactReusedEvent/3.0.0.yml
+++ b/definitions/EiffelArtifactReusedEvent/3.0.0.yml
@@ -94,17 +94,17 @@ _links:
         - EiffelArtifactCreatedEvent
 _history:
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelArtifactReusedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelArtifactReusedEvent/3.0.0.yml
+++ b/definitions/EiffelArtifactReusedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelArtifactReusedEvent/3.1.0.yml
+++ b/definitions/EiffelArtifactReusedEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelArtifactReusedEvent/3.1.0.yml
+++ b/definitions/EiffelArtifactReusedEvent/3.1.0.yml
@@ -94,21 +94,21 @@ _links:
         - EiffelArtifactCreatedEvent
 _history:
   - version: 3.1.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelArtifactReusedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelArtifactReusedEvent/3.2.0.yml
+++ b/definitions/EiffelArtifactReusedEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelArtifactReusedEvent/3.2.0.yml
+++ b/definitions/EiffelArtifactReusedEvent/3.2.0.yml
@@ -94,24 +94,24 @@ _links:
         - EiffelArtifactCreatedEvent
 _history:
   - version: 3.2.0
-    introduced_in: '[edition-arica](../../../tree/edition-arica)'
+    introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
   - version: 3.1.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelArtifactReusedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelCompositionDefinedEvent/1.0.0.yml
+++ b/definitions/EiffelCompositionDefinedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelCompositionDefinedEvent/1.0.0.yml
+++ b/definitions/EiffelCompositionDefinedEvent/1.0.0.yml
@@ -109,7 +109,7 @@ _links:
         - EiffelCompositionDefinedEvent
 _history:
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelCompositionDefinedEvent/1.1.0.yml
+++ b/definitions/EiffelCompositionDefinedEvent/1.1.0.yml
@@ -109,10 +109,10 @@ _links:
         - EiffelCompositionDefinedEvent
 _history:
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelCompositionDefinedEvent/1.1.0.yml
+++ b/definitions/EiffelCompositionDefinedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelCompositionDefinedEvent/2.0.0.yml
+++ b/definitions/EiffelCompositionDefinedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelCompositionDefinedEvent/2.0.0.yml
+++ b/definitions/EiffelCompositionDefinedEvent/2.0.0.yml
@@ -109,14 +109,14 @@ _links:
         - EiffelCompositionDefinedEvent
 _history:
   - version: 2.0.0
-    introduced_in: Current version
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelCompositionDefinedEvent/3.0.0.yml
+++ b/definitions/EiffelCompositionDefinedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelCompositionDefinedEvent/3.0.0.yml
+++ b/definitions/EiffelCompositionDefinedEvent/3.0.0.yml
@@ -109,17 +109,17 @@ _links:
         - EiffelCompositionDefinedEvent
 _history:
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelCompositionDefinedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelCompositionDefinedEvent/3.1.0.yml
+++ b/definitions/EiffelCompositionDefinedEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelCompositionDefinedEvent/3.1.0.yml
+++ b/definitions/EiffelCompositionDefinedEvent/3.1.0.yml
@@ -110,21 +110,21 @@ _links:
         - EiffelCompositionDefinedEvent
 _history:
   - version: 3.1.0
-    introduced_in: '[edition-paris](../../../tree/edition-paris)'
+    introduced_in: edition-paris
     changes: Added SCC as valid target for ELEMENT links (see [Issue
       218](https://github.com/eiffel-community/eiffel/issues/218))
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelCompositionDefinedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelCompositionDefinedEvent/3.2.0.yml
+++ b/definitions/EiffelCompositionDefinedEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelCompositionDefinedEvent/3.2.0.yml
+++ b/definitions/EiffelCompositionDefinedEvent/3.2.0.yml
@@ -110,25 +110,25 @@ _links:
         - EiffelCompositionDefinedEvent
 _history:
   - version: 3.2.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.1.0
-    introduced_in: '[edition-paris](../../../tree/edition-paris)'
+    introduced_in: edition-paris
     changes: Added SCC as valid target for ELEMENT links (see [Issue
       218](https://github.com/eiffel-community/eiffel/issues/218))
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelCompositionDefinedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelCompositionDefinedEvent/3.3.0.yml
+++ b/definitions/EiffelCompositionDefinedEvent/3.3.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelCompositionDefinedEvent/3.3.0.yml
+++ b/definitions/EiffelCompositionDefinedEvent/3.3.0.yml
@@ -110,28 +110,28 @@ _links:
         - EiffelCompositionDefinedEvent
 _history:
   - version: 3.3.0
-    introduced_in: '[edition-arica](../../../tree/edition-arica)'
+    introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
   - version: 3.2.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.1.0
-    introduced_in: '[edition-paris](../../../tree/edition-paris)'
+    introduced_in: edition-paris
     changes: Added SCC as valid target for ELEMENT links (see [Issue
       218](https://github.com/eiffel-community/eiffel/issues/218))
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelCompositionDefinedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelConfidenceLevelModifiedEvent/1.0.0.yml
+++ b/definitions/EiffelConfidenceLevelModifiedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelConfidenceLevelModifiedEvent/1.0.0.yml
+++ b/definitions/EiffelConfidenceLevelModifiedEvent/1.0.0.yml
@@ -140,7 +140,7 @@ _links:
         - EiffelConfidenceLevelModifiedEvent
 _history:
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelConfidenceLevelModifiedEvent/1.1.0.yml
+++ b/definitions/EiffelConfidenceLevelModifiedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelConfidenceLevelModifiedEvent/1.1.0.yml
+++ b/definitions/EiffelConfidenceLevelModifiedEvent/1.1.0.yml
@@ -140,10 +140,10 @@ _links:
         - EiffelConfidenceLevelModifiedEvent
 _history:
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelConfidenceLevelModifiedEvent/2.0.0.yml
+++ b/definitions/EiffelConfidenceLevelModifiedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelConfidenceLevelModifiedEvent/2.0.0.yml
+++ b/definitions/EiffelConfidenceLevelModifiedEvent/2.0.0.yml
@@ -140,14 +140,14 @@ _links:
         - EiffelConfidenceLevelModifiedEvent
 _history:
   - version: 2.0.0
-    introduced_in: Current version
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelConfidenceLevelModifiedEvent/3.0.0.yml
+++ b/definitions/EiffelConfidenceLevelModifiedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelConfidenceLevelModifiedEvent/3.0.0.yml
+++ b/definitions/EiffelConfidenceLevelModifiedEvent/3.0.0.yml
@@ -140,17 +140,17 @@ _links:
         - EiffelConfidenceLevelModifiedEvent
 _history:
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelConfidenceLevelModifiedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelConfidenceLevelModifiedEvent/3.1.0.yml
+++ b/definitions/EiffelConfidenceLevelModifiedEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelConfidenceLevelModifiedEvent/3.1.0.yml
+++ b/definitions/EiffelConfidenceLevelModifiedEvent/3.1.0.yml
@@ -140,21 +140,21 @@ _links:
         - EiffelConfidenceLevelModifiedEvent
 _history:
   - version: 3.1.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelConfidenceLevelModifiedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelConfidenceLevelModifiedEvent/3.2.0.yml
+++ b/definitions/EiffelConfidenceLevelModifiedEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelConfidenceLevelModifiedEvent/3.2.0.yml
+++ b/definitions/EiffelConfidenceLevelModifiedEvent/3.2.0.yml
@@ -140,24 +140,24 @@ _links:
         - EiffelConfidenceLevelModifiedEvent
 _history:
   - version: 3.2.0
-    introduced_in: '[edition-arica](../../../tree/edition-arica)'
+    introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
   - version: 3.1.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelConfidenceLevelModifiedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelConfidenceLevelModifiedEvent/3.3.0.yml
+++ b/definitions/EiffelConfidenceLevelModifiedEvent/3.3.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelConfidenceLevelModifiedEvent/3.3.0.yml
+++ b/definitions/EiffelConfidenceLevelModifiedEvent/3.3.0.yml
@@ -141,29 +141,28 @@ _links:
         - EiffelConfidenceLevelModifiedEvent
 _history:
   - version: 3.3.0
-    introduced_in: No edition set
     changes: Add EiffelArtifactDeployedEvent as legal target type for
       SUBJECT link (see
       [Issue 239](https://github.com/eiffel-community/eiffel/issues/239)).
   - version: 3.2.0
-    introduced_in: '[edition-arica](../../../tree/edition-arica)'
+    introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
   - version: 3.1.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelConfidenceLevelModifiedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelEnvironmentDefinedEvent/1.0.0.yml
+++ b/definitions/EiffelEnvironmentDefinedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelEnvironmentDefinedEvent/1.0.0.yml
+++ b/definitions/EiffelEnvironmentDefinedEvent/1.0.0.yml
@@ -132,7 +132,7 @@ _links:
         - EiffelEnvironmentDefinedEvent
 _history:
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: URI example

--- a/definitions/EiffelEnvironmentDefinedEvent/1.1.0.yml
+++ b/definitions/EiffelEnvironmentDefinedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelEnvironmentDefinedEvent/1.1.0.yml
+++ b/definitions/EiffelEnvironmentDefinedEvent/1.1.0.yml
@@ -132,10 +132,10 @@ _links:
         - EiffelEnvironmentDefinedEvent
 _history:
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: URI example

--- a/definitions/EiffelEnvironmentDefinedEvent/2.0.0.yml
+++ b/definitions/EiffelEnvironmentDefinedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelEnvironmentDefinedEvent/2.0.0.yml
+++ b/definitions/EiffelEnvironmentDefinedEvent/2.0.0.yml
@@ -132,14 +132,14 @@ _links:
         - EiffelEnvironmentDefinedEvent
 _history:
   - version: 2.0.0
-    introduced_in: Current version
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: URI example

--- a/definitions/EiffelEnvironmentDefinedEvent/3.0.0.yml
+++ b/definitions/EiffelEnvironmentDefinedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelEnvironmentDefinedEvent/3.0.0.yml
+++ b/definitions/EiffelEnvironmentDefinedEvent/3.0.0.yml
@@ -132,17 +132,17 @@ _links:
         - EiffelEnvironmentDefinedEvent
 _history:
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelEnvironmentDefinedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: URI example

--- a/definitions/EiffelEnvironmentDefinedEvent/3.1.0.yml
+++ b/definitions/EiffelEnvironmentDefinedEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelEnvironmentDefinedEvent/3.1.0.yml
+++ b/definitions/EiffelEnvironmentDefinedEvent/3.1.0.yml
@@ -148,20 +148,20 @@ _links:
         - EiffelCompositionDefinedEvent
 _history:
   - version: 3.1.0
-    introduced_in: Current version
+    introduced_in: edition-lyon
     changes: Added RUNTIME_ENVIRONMENT link type.
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelEnvironmentDefinedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: URI example

--- a/definitions/EiffelEnvironmentDefinedEvent/3.2.0.yml
+++ b/definitions/EiffelEnvironmentDefinedEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelEnvironmentDefinedEvent/3.2.0.yml
+++ b/definitions/EiffelEnvironmentDefinedEvent/3.2.0.yml
@@ -148,24 +148,24 @@ _links:
         - EiffelCompositionDefinedEvent
 _history:
   - version: 3.2.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.1.0
-    introduced_in: No edition set
+    introduced_in: edition-lyon
     changes: Added RUNTIME_ENVIRONMENT link type.
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelEnvironmentDefinedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: URI example

--- a/definitions/EiffelEnvironmentDefinedEvent/3.3.0.yml
+++ b/definitions/EiffelEnvironmentDefinedEvent/3.3.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelEnvironmentDefinedEvent/3.3.0.yml
+++ b/definitions/EiffelEnvironmentDefinedEvent/3.3.0.yml
@@ -148,27 +148,27 @@ _links:
         - EiffelCompositionDefinedEvent
 _history:
   - version: 3.3.0
-    introduced_in: '[edition-arica](../../../tree/edition-arica)'
+    introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
   - version: 3.2.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.1.0
-    introduced_in: No edition set
+    introduced_in: edition-lyon
     changes: Added RUNTIME_ENVIRONMENT link type.
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelEnvironmentDefinedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: URI example

--- a/definitions/EiffelFlowContextDefinedEvent/1.0.0.yml
+++ b/definitions/EiffelFlowContextDefinedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelFlowContextDefinedEvent/1.0.0.yml
+++ b/definitions/EiffelFlowContextDefinedEvent/1.0.0.yml
@@ -99,7 +99,7 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelFlowContextDefinedEvent/1.1.0.yml
+++ b/definitions/EiffelFlowContextDefinedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelFlowContextDefinedEvent/1.1.0.yml
+++ b/definitions/EiffelFlowContextDefinedEvent/1.1.0.yml
@@ -99,10 +99,10 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelFlowContextDefinedEvent/2.0.0.yml
+++ b/definitions/EiffelFlowContextDefinedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelFlowContextDefinedEvent/2.0.0.yml
+++ b/definitions/EiffelFlowContextDefinedEvent/2.0.0.yml
@@ -99,14 +99,14 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 2.0.0
-    introduced_in: Current version
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelFlowContextDefinedEvent/3.0.0.yml
+++ b/definitions/EiffelFlowContextDefinedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelFlowContextDefinedEvent/3.0.0.yml
+++ b/definitions/EiffelFlowContextDefinedEvent/3.0.0.yml
@@ -99,17 +99,17 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelFlowContextDefinedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelFlowContextDefinedEvent/3.1.0.yml
+++ b/definitions/EiffelFlowContextDefinedEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelFlowContextDefinedEvent/3.1.0.yml
+++ b/definitions/EiffelFlowContextDefinedEvent/3.1.0.yml
@@ -99,21 +99,21 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 3.1.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelFlowContextDefinedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelFlowContextDefinedEvent/3.2.0.yml
+++ b/definitions/EiffelFlowContextDefinedEvent/3.2.0.yml
@@ -99,24 +99,24 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 3.2.0
-    introduced_in: '[edition-arica](../../../tree/edition-arica)'
+    introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
   - version: 3.1.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelFlowContextDefinedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelFlowContextDefinedEvent/3.2.0.yml
+++ b/definitions/EiffelFlowContextDefinedEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelIssueDefinedEvent/1.0.0.yml
+++ b/definitions/EiffelIssueDefinedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelIssueDefinedEvent/1.0.0.yml
+++ b/definitions/EiffelIssueDefinedEvent/1.0.0.yml
@@ -114,7 +114,7 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 1.0.0
-    introduced_in: Current version
+    introduced_in: edition-agen
     changes: Initial version
 _examples:
   - title: Simple example

--- a/definitions/EiffelIssueDefinedEvent/2.0.0.yml
+++ b/definitions/EiffelIssueDefinedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelIssueDefinedEvent/2.0.0.yml
+++ b/definitions/EiffelIssueDefinedEvent/2.0.0.yml
@@ -114,11 +114,11 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 2.0.0
-    introduced_in: Current version
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.0.0
-    introduced_in: '[0706840](../../../blob/070684053ceb1da5fb42d9f0ef21df816961d6bc/eiffel-vocabulary/EiffelIssueDefinedEvent.md)'
+    introduced_in: edition-agen
     changes: Initial version
 _examples:
   - title: Simple example

--- a/definitions/EiffelIssueDefinedEvent/3.0.0.yml
+++ b/definitions/EiffelIssueDefinedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelIssueDefinedEvent/3.0.0.yml
+++ b/definitions/EiffelIssueDefinedEvent/3.0.0.yml
@@ -114,14 +114,14 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelIssueDefinedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.0.0
-    introduced_in: '[0706840](../../../blob/070684053ceb1da5fb42d9f0ef21df816961d6bc/eiffel-vocabulary/EiffelIssueDefinedEvent.md)'
+    introduced_in: edition-agen
     changes: Initial version
 _examples:
   - title: Simple example

--- a/definitions/EiffelIssueDefinedEvent/3.1.0.yml
+++ b/definitions/EiffelIssueDefinedEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelIssueDefinedEvent/3.1.0.yml
+++ b/definitions/EiffelIssueDefinedEvent/3.1.0.yml
@@ -114,18 +114,18 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 3.1.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelIssueDefinedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.0.0
-    introduced_in: '[0706840](../../../blob/070684053ceb1da5fb42d9f0ef21df816961d6bc/eiffel-vocabulary/EiffelIssueDefinedEvent.md)'
+    introduced_in: edition-agen
     changes: Initial version
 _examples:
   - title: Simple example

--- a/definitions/EiffelIssueDefinedEvent/3.2.0.yml
+++ b/definitions/EiffelIssueDefinedEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelIssueDefinedEvent/3.2.0.yml
+++ b/definitions/EiffelIssueDefinedEvent/3.2.0.yml
@@ -114,21 +114,21 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 3.2.0
-    introduced_in: '[edition-arica](../../../tree/edition-arica)'
+    introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
   - version: 3.1.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelIssueDefinedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.0.0
-    introduced_in: '[0706840](../../../blob/070684053ceb1da5fb42d9f0ef21df816961d6bc/eiffel-vocabulary/EiffelIssueDefinedEvent.md)'
+    introduced_in: edition-agen
     changes: Initial version
 _examples:
   - title: Simple example

--- a/definitions/EiffelIssueVerifiedEvent/1.0.0.yml
+++ b/definitions/EiffelIssueVerifiedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelIssueVerifiedEvent/1.0.0.yml
+++ b/definitions/EiffelIssueVerifiedEvent/1.0.0.yml
@@ -163,7 +163,7 @@ _links:
         - EiffelTestSuiteFinishedEvent
 _history:
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelIssueVerifiedEvent/1.1.0.yml
+++ b/definitions/EiffelIssueVerifiedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelIssueVerifiedEvent/1.1.0.yml
+++ b/definitions/EiffelIssueVerifiedEvent/1.1.0.yml
@@ -163,10 +163,10 @@ _links:
         - EiffelTestSuiteFinishedEvent
 _history:
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelIssueVerifiedEvent/2.0.0.yml
+++ b/definitions/EiffelIssueVerifiedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelIssueVerifiedEvent/2.0.0.yml
+++ b/definitions/EiffelIssueVerifiedEvent/2.0.0.yml
@@ -129,13 +129,13 @@ _links:
         - EiffelTestSuiteFinishedEvent
 _history:
   - version: 2.0.0
-    introduced_in: Current version
+    introduced_in: edition-agen
     changes: Replaced data.issues with links
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelIssueVerifiedEvent/3.0.0.yml
+++ b/definitions/EiffelIssueVerifiedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelIssueVerifiedEvent/3.0.0.yml
+++ b/definitions/EiffelIssueVerifiedEvent/3.0.0.yml
@@ -129,17 +129,17 @@ _links:
         - EiffelTestSuiteFinishedEvent
 _history:
   - version: 3.0.0
-    introduced_in: Current version
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 2.0.0
-    introduced_in: '[0706840](../../../blob/070684053ceb1da5fb42d9f0ef21df816961d6bc/eiffel-vocabulary/EiffelIssueVerifiedEvent.md)'
+    introduced_in: edition-agen
     changes: Replaced data.issues with links
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelIssueVerifiedEvent/4.0.0.yml
+++ b/definitions/EiffelIssueVerifiedEvent/4.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelIssueVerifiedEvent/4.0.0.yml
+++ b/definitions/EiffelIssueVerifiedEvent/4.0.0.yml
@@ -129,20 +129,20 @@ _links:
         - EiffelTestSuiteFinishedEvent
 _history:
   - version: 4.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 3.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelIssueVerifiedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 2.0.0
-    introduced_in: '[0706840](../../../blob/070684053ceb1da5fb42d9f0ef21df816961d6bc/eiffel-vocabulary/EiffelIssueVerifiedEvent.md)'
+    introduced_in: edition-agen
     changes: Replaced data.issues with links
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelIssueVerifiedEvent/4.1.0.yml
+++ b/definitions/EiffelIssueVerifiedEvent/4.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelIssueVerifiedEvent/4.1.0.yml
+++ b/definitions/EiffelIssueVerifiedEvent/4.1.0.yml
@@ -129,24 +129,24 @@ _links:
         - EiffelTestSuiteFinishedEvent
 _history:
   - version: 4.1.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 4.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 3.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelIssueVerifiedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 2.0.0
-    introduced_in: '[0706840](../../../blob/070684053ceb1da5fb42d9f0ef21df816961d6bc/eiffel-vocabulary/EiffelIssueVerifiedEvent.md)'
+    introduced_in: edition-agen
     changes: Replaced data.issues with links
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelIssueVerifiedEvent/4.2.0.yml
+++ b/definitions/EiffelIssueVerifiedEvent/4.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelIssueVerifiedEvent/4.2.0.yml
+++ b/definitions/EiffelIssueVerifiedEvent/4.2.0.yml
@@ -129,27 +129,27 @@ _links:
         - EiffelTestSuiteFinishedEvent
 _history:
   - version: 4.2.0
-    introduced_in: '[edition-arica](../../../tree/edition-arica)'
+    introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
   - version: 4.1.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 4.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 3.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelIssueVerifiedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 2.0.0
-    introduced_in: '[0706840](../../../blob/070684053ceb1da5fb42d9f0ef21df816961d6bc/eiffel-vocabulary/EiffelIssueVerifiedEvent.md)'
+    introduced_in: edition-agen
     changes: Replaced data.issues with links
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelIssueVerifiedEvent/4.3.0.yml
+++ b/definitions/EiffelIssueVerifiedEvent/4.3.0.yml
@@ -130,30 +130,29 @@ _links:
         - EiffelTestSuiteFinishedEvent
 _history:
   - version: 4.3.0
-    introduced_in: No edition set
     changes: Add artifact deployed event as legal IUT target (see [Issue 239](https://github.com/eiffel-community/eiffel/issues/239)).
   - version: 4.2.0
-    introduced_in: '[edition-arica](../../../tree/edition-arica)'
+    introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
   - version: 4.1.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 4.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 3.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelIssueVerifiedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 2.0.0
-    introduced_in: '[0706840](../../../blob/070684053ceb1da5fb42d9f0ef21df816961d6bc/eiffel-vocabulary/EiffelIssueVerifiedEvent.md)'
+    introduced_in: edition-agen
     changes: Replaced data.issues with links
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelSourceChangeCreatedEvent/1.0.0.yml
+++ b/definitions/EiffelSourceChangeCreatedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelSourceChangeCreatedEvent/1.0.0.yml
+++ b/definitions/EiffelSourceChangeCreatedEvent/1.0.0.yml
@@ -268,7 +268,7 @@ _links:
         - EiffelSourceChangeCreatedEvent
 _history:
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelSourceChangeCreatedEvent/1.1.0.yml
+++ b/definitions/EiffelSourceChangeCreatedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelSourceChangeCreatedEvent/1.1.0.yml
+++ b/definitions/EiffelSourceChangeCreatedEvent/1.1.0.yml
@@ -268,10 +268,10 @@ _links:
         - EiffelSourceChangeCreatedEvent
 _history:
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelSourceChangeCreatedEvent/2.0.0.yml
+++ b/definitions/EiffelSourceChangeCreatedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelSourceChangeCreatedEvent/2.0.0.yml
+++ b/definitions/EiffelSourceChangeCreatedEvent/2.0.0.yml
@@ -270,13 +270,13 @@ _links:
         - EiffelIssueDefinedEvent
 _history:
   - version: 2.0.0
-    introduced_in: Current version
+    introduced_in: edition-agen
     changes: Replaced data.issues with links
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelSourceChangeCreatedEvent/3.0.0.yml
+++ b/definitions/EiffelSourceChangeCreatedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelSourceChangeCreatedEvent/3.0.0.yml
+++ b/definitions/EiffelSourceChangeCreatedEvent/3.0.0.yml
@@ -270,17 +270,17 @@ _links:
         - EiffelIssueDefinedEvent
 _history:
   - version: 3.0.0
-    introduced_in: Current version
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 2.0.0
-    introduced_in: '[0706840](../../../blob/070684053ceb1da5fb42d9f0ef21df816961d6bc/eiffel-vocabulary/EiffelSourceChangeCreatedEvent.md)'
+    introduced_in: edition-agen
     changes: Replaced data.issues with links
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelSourceChangeCreatedEvent/4.0.0.yml
+++ b/definitions/EiffelSourceChangeCreatedEvent/4.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelSourceChangeCreatedEvent/4.0.0.yml
+++ b/definitions/EiffelSourceChangeCreatedEvent/4.0.0.yml
@@ -270,20 +270,20 @@ _links:
         - EiffelIssueDefinedEvent
 _history:
   - version: 4.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 3.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelSourceChangeCreatedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 2.0.0
-    introduced_in: '[0706840](../../../blob/070684053ceb1da5fb42d9f0ef21df816961d6bc/eiffel-vocabulary/EiffelSourceChangeCreatedEvent.md)'
+    introduced_in: edition-agen
     changes: Replaced data.issues with links
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelSourceChangeCreatedEvent/4.1.0.yml
+++ b/definitions/EiffelSourceChangeCreatedEvent/4.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelSourceChangeCreatedEvent/4.1.0.yml
+++ b/definitions/EiffelSourceChangeCreatedEvent/4.1.0.yml
@@ -270,24 +270,24 @@ _links:
         - EiffelIssueDefinedEvent
 _history:
   - version: 4.1.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 4.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 3.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelSourceChangeCreatedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 2.0.0
-    introduced_in: '[0706840](../../../blob/070684053ceb1da5fb42d9f0ef21df816961d6bc/eiffel-vocabulary/EiffelSourceChangeCreatedEvent.md)'
+    introduced_in: edition-agen
     changes: Replaced data.issues with links
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelSourceChangeCreatedEvent/4.2.0.yml
+++ b/definitions/EiffelSourceChangeCreatedEvent/4.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelSourceChangeCreatedEvent/4.2.0.yml
+++ b/definitions/EiffelSourceChangeCreatedEvent/4.2.0.yml
@@ -270,27 +270,27 @@ _links:
         - EiffelIssueDefinedEvent
 _history:
   - version: 4.2.0
-    introduced_in: '[edition-arica](../../../tree/edition-arica)'
+    introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
   - version: 4.1.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 4.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 3.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelSourceChangeCreatedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 2.0.0
-    introduced_in: '[0706840](../../../blob/070684053ceb1da5fb42d9f0ef21df816961d6bc/eiffel-vocabulary/EiffelSourceChangeCreatedEvent.md)'
+    introduced_in: edition-agen
     changes: Replaced data.issues with links
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelSourceChangeSubmittedEvent/1.0.0.yml
+++ b/definitions/EiffelSourceChangeSubmittedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelSourceChangeSubmittedEvent/1.0.0.yml
+++ b/definitions/EiffelSourceChangeSubmittedEvent/1.0.0.yml
@@ -203,7 +203,7 @@ _links:
         - EiffelSourceChangeSubmittedEvent
 _history:
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelSourceChangeSubmittedEvent/1.1.0.yml
+++ b/definitions/EiffelSourceChangeSubmittedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelSourceChangeSubmittedEvent/1.1.0.yml
+++ b/definitions/EiffelSourceChangeSubmittedEvent/1.1.0.yml
@@ -203,10 +203,10 @@ _links:
         - EiffelSourceChangeSubmittedEvent
 _history:
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelSourceChangeSubmittedEvent/2.0.0.yml
+++ b/definitions/EiffelSourceChangeSubmittedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelSourceChangeSubmittedEvent/2.0.0.yml
+++ b/definitions/EiffelSourceChangeSubmittedEvent/2.0.0.yml
@@ -203,14 +203,14 @@ _links:
         - EiffelSourceChangeSubmittedEvent
 _history:
   - version: 2.0.0
-    introduced_in: Current version
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelSourceChangeSubmittedEvent/3.0.0.yml
+++ b/definitions/EiffelSourceChangeSubmittedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelSourceChangeSubmittedEvent/3.0.0.yml
+++ b/definitions/EiffelSourceChangeSubmittedEvent/3.0.0.yml
@@ -203,17 +203,17 @@ _links:
         - EiffelSourceChangeSubmittedEvent
 _history:
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelSourceChangeCreatedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelSourceChangeSubmittedEvent/3.1.0.yml
+++ b/definitions/EiffelSourceChangeSubmittedEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelSourceChangeSubmittedEvent/3.1.0.yml
+++ b/definitions/EiffelSourceChangeSubmittedEvent/3.1.0.yml
@@ -203,21 +203,21 @@ _links:
         - EiffelSourceChangeSubmittedEvent
 _history:
   - version: 3.1.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelSourceChangeCreatedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelSourceChangeSubmittedEvent/3.2.0.yml
+++ b/definitions/EiffelSourceChangeSubmittedEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelSourceChangeSubmittedEvent/3.2.0.yml
+++ b/definitions/EiffelSourceChangeSubmittedEvent/3.2.0.yml
@@ -203,24 +203,24 @@ _links:
         - EiffelSourceChangeSubmittedEvent
 _history:
   - version: 3.2.0
-    introduced_in: '[edition-arica](../../../tree/edition-arica)'
+    introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
   - version: 3.1.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelSourceChangeCreatedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestCaseCanceledEvent/1.0.0.yml
+++ b/definitions/EiffelTestCaseCanceledEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestCaseCanceledEvent/1.0.0.yml
+++ b/definitions/EiffelTestCaseCanceledEvent/1.0.0.yml
@@ -95,7 +95,7 @@ _links:
         - EiffelTestCaseTriggeredEvent
 _history:
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestCaseCanceledEvent/1.1.0.yml
+++ b/definitions/EiffelTestCaseCanceledEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestCaseCanceledEvent/1.1.0.yml
+++ b/definitions/EiffelTestCaseCanceledEvent/1.1.0.yml
@@ -95,10 +95,10 @@ _links:
         - EiffelTestCaseTriggeredEvent
 _history:
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestCaseCanceledEvent/2.0.0.yml
+++ b/definitions/EiffelTestCaseCanceledEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestCaseCanceledEvent/2.0.0.yml
+++ b/definitions/EiffelTestCaseCanceledEvent/2.0.0.yml
@@ -95,14 +95,14 @@ _links:
         - EiffelTestCaseTriggeredEvent
 _history:
   - version: 2.0.0
-    introduced_in: Current version
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestCaseCanceledEvent/3.0.0.yml
+++ b/definitions/EiffelTestCaseCanceledEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestCaseCanceledEvent/3.0.0.yml
+++ b/definitions/EiffelTestCaseCanceledEvent/3.0.0.yml
@@ -95,17 +95,17 @@ _links:
         - EiffelTestCaseTriggeredEvent
 _history:
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestCaseCanceledEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestCaseCanceledEvent/3.1.0.yml
+++ b/definitions/EiffelTestCaseCanceledEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestCaseCanceledEvent/3.1.0.yml
+++ b/definitions/EiffelTestCaseCanceledEvent/3.1.0.yml
@@ -95,21 +95,21 @@ _links:
         - EiffelTestCaseTriggeredEvent
 _history:
   - version: 3.1.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestCaseCanceledEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestCaseCanceledEvent/3.2.0.yml
+++ b/definitions/EiffelTestCaseCanceledEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestCaseCanceledEvent/3.2.0.yml
+++ b/definitions/EiffelTestCaseCanceledEvent/3.2.0.yml
@@ -95,24 +95,24 @@ _links:
         - EiffelTestCaseTriggeredEvent
 _history:
   - version: 3.2.0
-    introduced_in: '[edition-arica](../../../tree/edition-arica)'
+    introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
   - version: 3.1.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestCaseCanceledEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestCaseFinishedEvent/1.0.0.yml
+++ b/definitions/EiffelTestCaseFinishedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestCaseFinishedEvent/1.0.0.yml
+++ b/definitions/EiffelTestCaseFinishedEvent/1.0.0.yml
@@ -120,6 +120,6 @@ additionalProperties: false
 _links: {}
 _history:
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples: []

--- a/definitions/EiffelTestCaseFinishedEvent/1.0.1.yml
+++ b/definitions/EiffelTestCaseFinishedEvent/1.0.1.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestCaseFinishedEvent/1.0.1.yml
+++ b/definitions/EiffelTestCaseFinishedEvent/1.0.1.yml
@@ -170,11 +170,11 @@ _links:
         - EiffelTestCaseTriggeredEvent
 _history:
   - version: 1.0.1
-    introduced_in: Current version
+    introduced_in: edition-toulouse
     changes: data.outcome.metrics.value and data.outcome.metrics.name
       made mandatory.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestCaseFinishedEvent/1.1.0.yml
+++ b/definitions/EiffelTestCaseFinishedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestCaseFinishedEvent/1.1.0.yml
+++ b/definitions/EiffelTestCaseFinishedEvent/1.1.0.yml
@@ -170,14 +170,14 @@ _links:
         - EiffelTestCaseTriggeredEvent
 _history:
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.1
-    introduced_in: '[0a2f9ef](../../../blob/0a2f9ef139fe6ead2493e5deddf1337ffb3dd4af/eiffel-vocabulary/EiffelTestCaseFinishedEvent.md)'
+    introduced_in: edition-toulouse
     changes: data.outcome.metrics.value and data.outcome.metrics.name
       made mandatory.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestCaseFinishedEvent/2.0.0.yml
+++ b/definitions/EiffelTestCaseFinishedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestCaseFinishedEvent/2.0.0.yml
+++ b/definitions/EiffelTestCaseFinishedEvent/2.0.0.yml
@@ -170,18 +170,18 @@ _links:
         - EiffelTestCaseTriggeredEvent
 _history:
   - version: 2.0.0
-    introduced_in: Current version
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.1
-    introduced_in: '[0a2f9ef](../../../blob/0a2f9ef139fe6ead2493e5deddf1337ffb3dd4af/eiffel-vocabulary/EiffelTestCaseFinishedEvent.md)'
+    introduced_in: edition-toulouse
     changes: data.outcome.metrics.value and data.outcome.metrics.name
       made mandatory.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestCaseFinishedEvent/3.0.0.yml
+++ b/definitions/EiffelTestCaseFinishedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestCaseFinishedEvent/3.0.0.yml
+++ b/definitions/EiffelTestCaseFinishedEvent/3.0.0.yml
@@ -170,21 +170,21 @@ _links:
         - EiffelTestCaseTriggeredEvent
 _history:
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestCaseFinishedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.1
-    introduced_in: '[0a2f9ef](../../../blob/0a2f9ef139fe6ead2493e5deddf1337ffb3dd4af/eiffel-vocabulary/EiffelTestCaseFinishedEvent.md)'
+    introduced_in: edition-toulouse
     changes: data.outcome.metrics.value and data.outcome.metrics.name
       made mandatory.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestCaseFinishedEvent/3.1.0.yml
+++ b/definitions/EiffelTestCaseFinishedEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestCaseFinishedEvent/3.1.0.yml
+++ b/definitions/EiffelTestCaseFinishedEvent/3.1.0.yml
@@ -183,24 +183,24 @@ _links:
         - EiffelTestCaseTriggeredEvent
 _history:
   - version: 3.1.0
-    introduced_in: Current version
+    introduced_in: edition-lyon
     changes: Add `data.persistentLogs.{mediaType,tags}`.
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestCaseFinishedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.1
-    introduced_in: '[0a2f9ef](../../../blob/0a2f9ef139fe6ead2493e5deddf1337ffb3dd4af/eiffel-vocabulary/EiffelTestCaseFinishedEvent.md)'
+    introduced_in: edition-toulouse
     changes: data.outcome.metrics.value and data.outcome.metrics.name
       made mandatory.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestCaseFinishedEvent/3.2.0.yml
+++ b/definitions/EiffelTestCaseFinishedEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestCaseFinishedEvent/3.2.0.yml
+++ b/definitions/EiffelTestCaseFinishedEvent/3.2.0.yml
@@ -183,28 +183,28 @@ _links:
         - EiffelTestCaseTriggeredEvent
 _history:
   - version: 3.2.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.1.0
-    introduced_in: No edition set
+    introduced_in: edition-lyon
     changes: Add `data.persistentLogs.{mediaType,tags}`.
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestCaseFinishedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.1
-    introduced_in: '[0a2f9ef](../../../blob/0a2f9ef139fe6ead2493e5deddf1337ffb3dd4af/eiffel-vocabulary/EiffelTestCaseFinishedEvent.md)'
+    introduced_in: edition-toulouse
     changes: data.outcome.metrics.value and data.outcome.metrics.name
       made mandatory.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestCaseFinishedEvent/3.3.0.yml
+++ b/definitions/EiffelTestCaseFinishedEvent/3.3.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestCaseFinishedEvent/3.3.0.yml
+++ b/definitions/EiffelTestCaseFinishedEvent/3.3.0.yml
@@ -183,31 +183,31 @@ _links:
         - EiffelTestCaseTriggeredEvent
 _history:
   - version: 3.3.0
-    introduced_in: '[edition-arica](../../../tree/edition-arica)'
+    introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
   - version: 3.2.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.1.0
-    introduced_in: No edition set
+    introduced_in: edition-lyon
     changes: Add `data.persistentLogs.{mediaType,tags}`.
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestCaseFinishedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.1
-    introduced_in: '[0a2f9ef](../../../blob/0a2f9ef139fe6ead2493e5deddf1337ffb3dd4af/eiffel-vocabulary/EiffelTestCaseFinishedEvent.md)'
+    introduced_in: edition-toulouse
     changes: data.outcome.metrics.value and data.outcome.metrics.name
       made mandatory.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestCaseStartedEvent/1.0.0.yml
+++ b/definitions/EiffelTestCaseStartedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestCaseStartedEvent/1.0.0.yml
+++ b/definitions/EiffelTestCaseStartedEvent/1.0.0.yml
@@ -123,7 +123,7 @@ _links:
         - EiffelTestCaseTriggeredEvent
 _history:
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestCaseStartedEvent/1.1.0.yml
+++ b/definitions/EiffelTestCaseStartedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestCaseStartedEvent/1.1.0.yml
+++ b/definitions/EiffelTestCaseStartedEvent/1.1.0.yml
@@ -123,10 +123,10 @@ _links:
         - EiffelTestCaseTriggeredEvent
 _history:
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestCaseStartedEvent/2.0.0.yml
+++ b/definitions/EiffelTestCaseStartedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestCaseStartedEvent/2.0.0.yml
+++ b/definitions/EiffelTestCaseStartedEvent/2.0.0.yml
@@ -123,14 +123,14 @@ _links:
         - EiffelTestCaseTriggeredEvent
 _history:
   - version: 2.0.0
-    introduced_in: Current version
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestCaseStartedEvent/3.0.0.yml
+++ b/definitions/EiffelTestCaseStartedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestCaseStartedEvent/3.0.0.yml
+++ b/definitions/EiffelTestCaseStartedEvent/3.0.0.yml
@@ -123,17 +123,17 @@ _links:
         - EiffelTestCaseTriggeredEvent
 _history:
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestCaseStartedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestCaseStartedEvent/3.1.0.yml
+++ b/definitions/EiffelTestCaseStartedEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestCaseStartedEvent/3.1.0.yml
+++ b/definitions/EiffelTestCaseStartedEvent/3.1.0.yml
@@ -136,20 +136,20 @@ _links:
         - EiffelTestCaseTriggeredEvent
 _history:
   - version: 3.1.0
-    introduced_in: Current version
+    introduced_in: edition-lyon
     changes: Add `data.liveLogs.{mediaType,tags}`.
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestCaseStartedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestCaseStartedEvent/3.2.0.yml
+++ b/definitions/EiffelTestCaseStartedEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestCaseStartedEvent/3.2.0.yml
+++ b/definitions/EiffelTestCaseStartedEvent/3.2.0.yml
@@ -136,24 +136,24 @@ _links:
         - EiffelTestCaseTriggeredEvent
 _history:
   - version: 3.2.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.1.0
-    introduced_in: No edition set
+    introduced_in: edition-lyon
     changes: Add `data.liveLogs.{mediaType,tags}`.
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestCaseStartedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestCaseStartedEvent/3.3.0.yml
+++ b/definitions/EiffelTestCaseStartedEvent/3.3.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestCaseStartedEvent/3.3.0.yml
+++ b/definitions/EiffelTestCaseStartedEvent/3.3.0.yml
@@ -136,27 +136,27 @@ _links:
         - EiffelTestCaseTriggeredEvent
 _history:
   - version: 3.3.0
-    introduced_in: '[edition-arica](../../../tree/edition-arica)'
+    introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
   - version: 3.2.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.1.0
-    introduced_in: No edition set
+    introduced_in: edition-lyon
     changes: Add `data.liveLogs.{mediaType,tags}`.
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestCaseStartedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestCaseTriggeredEvent/1.0.0.yml
+++ b/definitions/EiffelTestCaseTriggeredEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestCaseTriggeredEvent/1.0.0.yml
+++ b/definitions/EiffelTestCaseTriggeredEvent/1.0.0.yml
@@ -173,7 +173,7 @@ _links:
         - EiffelCompositionDefinedEvent
 _history:
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestCaseTriggeredEvent/1.1.0.yml
+++ b/definitions/EiffelTestCaseTriggeredEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestCaseTriggeredEvent/1.1.0.yml
+++ b/definitions/EiffelTestCaseTriggeredEvent/1.1.0.yml
@@ -173,10 +173,10 @@ _links:
         - EiffelCompositionDefinedEvent
 _history:
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestCaseTriggeredEvent/2.0.0.yml
+++ b/definitions/EiffelTestCaseTriggeredEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestCaseTriggeredEvent/2.0.0.yml
+++ b/definitions/EiffelTestCaseTriggeredEvent/2.0.0.yml
@@ -173,14 +173,14 @@ _links:
         - EiffelCompositionDefinedEvent
 _history:
   - version: 2.0.0
-    introduced_in: Current version
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestCaseTriggeredEvent/3.0.0.yml
+++ b/definitions/EiffelTestCaseTriggeredEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestCaseTriggeredEvent/3.0.0.yml
+++ b/definitions/EiffelTestCaseTriggeredEvent/3.0.0.yml
@@ -173,17 +173,17 @@ _links:
         - EiffelCompositionDefinedEvent
 _history:
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestCaseTriggeredEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestCaseTriggeredEvent/3.1.0.yml
+++ b/definitions/EiffelTestCaseTriggeredEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestCaseTriggeredEvent/3.1.0.yml
+++ b/definitions/EiffelTestCaseTriggeredEvent/3.1.0.yml
@@ -187,21 +187,21 @@ _links:
         - EiffelTestCaseTriggeredEvent
 _history:
   - version: 3.1.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestCaseTriggeredEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestCaseTriggeredEvent/3.2.0.yml
+++ b/definitions/EiffelTestCaseTriggeredEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestCaseTriggeredEvent/3.2.0.yml
+++ b/definitions/EiffelTestCaseTriggeredEvent/3.2.0.yml
@@ -187,24 +187,24 @@ _links:
         - EiffelTestCaseTriggeredEvent
 _history:
   - version: 3.2.0
-    introduced_in: '[edition-arica](../../../tree/edition-arica)'
+    introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
   - version: 3.1.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestCaseTriggeredEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestCaseTriggeredEvent/3.3.0.yml
+++ b/definitions/EiffelTestCaseTriggeredEvent/3.3.0.yml
@@ -189,27 +189,26 @@ _links:
         - EiffelTestCaseTriggeredEvent
 _history:
   - version: 3.3.0
-    introduced_in: Current version
     changes: Add SCS and SCC as legal target for IUT in TCT (see [Issue 317](https://github.com/eiffel-community/eiffel/issues/317)).
   - version: 3.2.0
-    introduced_in: '[edition-arica](../../../tree/edition-arica)'
+    introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
   - version: 3.1.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestCaseTriggeredEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestCaseTriggeredEvent/3.4.0.yml
+++ b/definitions/EiffelTestCaseTriggeredEvent/3.4.0.yml
@@ -190,30 +190,28 @@ _links:
         - EiffelTestCaseTriggeredEvent
 _history:
   - version: 3.4.0
-    introduced_in: No edition set
     changes: Add artifact deployed event as legal IUT target (see [Issue 239](https://github.com/eiffel-community/eiffel/issues/239)).
   - version: 3.3.0
-    introduced_in: No edition set
     changes: Add SCS and SCC as legal target for IUT in TCT (see [Issue 317](https://github.com/eiffel-community/eiffel/issues/317)).
   - version: 3.2.0
-    introduced_in: '[edition-arica](../../../tree/edition-arica)'
+    introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
   - version: 3.1.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestCaseTriggeredEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/1.0.0.yml
+++ b/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/1.0.0.yml
+++ b/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/1.0.0.yml
@@ -183,6 +183,6 @@ additionalProperties: false
 _links: {}
 _history:
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples: []

--- a/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/2.0.0.yml
+++ b/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/2.0.0.yml
+++ b/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/2.0.0.yml
@@ -229,12 +229,12 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 2.0.0
-    introduced_in: Current version.
+    introduced_in: edition-toulouse
     changes: Changed syntax of data.batches.recipes.constraints from
       an uncontrolled object to a list of key-value pairs to comply
       with design guidelines.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Example using data.batches

--- a/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/2.1.0.yml
+++ b/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/2.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/2.1.0.yml
+++ b/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/2.1.0.yml
@@ -229,15 +229,15 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 2.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 2.0.0
-    introduced_in: '[f92e001](../../../blob/f92e001c88d1139a62f8ace976958e0a30d8f9c5/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md)'
+    introduced_in: edition-toulouse
     changes: Changed syntax of data.batches.recipes.constraints from
       an uncontrolled object to a list of key-value pairs to comply
       with design guidelines.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Example using data.batches

--- a/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/3.0.0.yml
+++ b/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/3.0.0.yml
+++ b/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/3.0.0.yml
@@ -229,19 +229,19 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 3.0.0
-    introduced_in: Current version
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 2.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 2.0.0
-    introduced_in: '[f92e001](../../../blob/f92e001c88d1139a62f8ace976958e0a30d8f9c5/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md)'
+    introduced_in: edition-toulouse
     changes: Changed syntax of data.batches.recipes.constraints from
       an uncontrolled object to a list of key-value pairs to comply
       with design guidelines.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Example using data.batches

--- a/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.0.0.yml
+++ b/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.0.0.yml
+++ b/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.0.0.yml
@@ -229,22 +229,22 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 4.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 3.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 2.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 2.0.0
-    introduced_in: '[f92e001](../../../blob/f92e001c88d1139a62f8ace976958e0a30d8f9c5/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md)'
+    introduced_in: edition-toulouse
     changes: Changed syntax of data.batches.recipes.constraints from
       an uncontrolled object to a list of key-value pairs to comply
       with design guidelines.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Example using data.batches

--- a/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.1.0.yml
+++ b/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.1.0.yml
+++ b/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.1.0.yml
@@ -229,25 +229,25 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 4.1.0
-    introduced_in: Current version
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 4.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 3.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 2.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 2.0.0
-    introduced_in: '[f92e001](../../../blob/f92e001c88d1139a62f8ace976958e0a30d8f9c5/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md)'
+    introduced_in: edition-toulouse
     changes: Changed syntax of data.batches.recipes.constraints from
       an uncontrolled object to a list of key-value pairs to comply
       with design guidelines.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Example using data.batches

--- a/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.1.1.yml
+++ b/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.1.1.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.1.1.yml
+++ b/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.1.1.yml
@@ -229,29 +229,29 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 4.1.1
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add missing validation pattern to links.target member
       (see [Issue 271](https://github.com/eiffel-community/eiffel/issues/271)).
   - version: 4.1.0
-    introduced_in: No edition set
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 4.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 3.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 2.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 2.0.0
-    introduced_in: '[f92e001](../../../blob/f92e001c88d1139a62f8ace976958e0a30d8f9c5/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md)'
+    introduced_in: edition-toulouse
     changes: Changed syntax of data.batches.recipes.constraints from
       an uncontrolled object to a list of key-value pairs to comply
       with design guidelines.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Example using data.batches

--- a/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.2.0.yml
+++ b/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.2.0.yml
+++ b/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.2.0.yml
@@ -238,33 +238,33 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 4.2.0
-    introduced_in: No edition set
+    introduced_in: edition-arica
     changes: Add missing testCase.version member (see [Issue 288](https://github.com/eiffel-community/eiffel/issues/288)).
   - version: 4.1.1
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add missing validation pattern to links.target member
       (see [Issue 271](https://github.com/eiffel-community/eiffel/issues/271)).
   - version: 4.1.0
-    introduced_in: No edition set
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 4.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 3.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 2.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 2.0.0
-    introduced_in: '[f92e001](../../../blob/f92e001c88d1139a62f8ace976958e0a30d8f9c5/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md)'
+    introduced_in: edition-toulouse
     changes: Changed syntax of data.batches.recipes.constraints from
       an uncontrolled object to a list of key-value pairs to comply
       with design guidelines.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Example using data.batches

--- a/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.3.0.yml
+++ b/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.3.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.3.0.yml
+++ b/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.3.0.yml
@@ -238,36 +238,36 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 4.3.0
-    introduced_in: '[edition-arica](../../../tree/edition-arica)'
+    introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
   - version: 4.2.0
-    introduced_in: No edition set
+    introduced_in: edition-arica
     changes: Add missing testCase.version member (see [Issue 288](https://github.com/eiffel-community/eiffel/issues/288)).
   - version: 4.1.1
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add missing validation pattern to links.target member
       (see [Issue 271](https://github.com/eiffel-community/eiffel/issues/271)).
   - version: 4.1.0
-    introduced_in: No edition set
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 4.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 3.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 2.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 2.0.0
-    introduced_in: '[f92e001](../../../blob/f92e001c88d1139a62f8ace976958e0a30d8f9c5/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md)'
+    introduced_in: edition-toulouse
     changes: Changed syntax of data.batches.recipes.constraints from
       an uncontrolled object to a list of key-value pairs to comply
       with design guidelines.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Example using data.batches

--- a/definitions/EiffelTestSuiteFinishedEvent/1.0.0.yml
+++ b/definitions/EiffelTestSuiteFinishedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestSuiteFinishedEvent/1.0.0.yml
+++ b/definitions/EiffelTestSuiteFinishedEvent/1.0.0.yml
@@ -137,7 +137,7 @@ _links:
         - EiffelTestSuiteStartedEvent
 _history:
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestSuiteFinishedEvent/1.1.0.yml
+++ b/definitions/EiffelTestSuiteFinishedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestSuiteFinishedEvent/1.1.0.yml
+++ b/definitions/EiffelTestSuiteFinishedEvent/1.1.0.yml
@@ -137,10 +137,10 @@ _links:
         - EiffelTestSuiteStartedEvent
 _history:
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestSuiteFinishedEvent/2.0.0.yml
+++ b/definitions/EiffelTestSuiteFinishedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestSuiteFinishedEvent/2.0.0.yml
+++ b/definitions/EiffelTestSuiteFinishedEvent/2.0.0.yml
@@ -137,14 +137,14 @@ _links:
         - EiffelTestSuiteStartedEvent
 _history:
   - version: 2.0.0
-    introduced_in: Current version
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestSuiteFinishedEvent/3.0.0.yml
+++ b/definitions/EiffelTestSuiteFinishedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestSuiteFinishedEvent/3.0.0.yml
+++ b/definitions/EiffelTestSuiteFinishedEvent/3.0.0.yml
@@ -137,17 +137,17 @@ _links:
         - EiffelTestSuiteStartedEvent
 _history:
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestSuiteFinishedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestSuiteFinishedEvent/3.1.0.yml
+++ b/definitions/EiffelTestSuiteFinishedEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestSuiteFinishedEvent/3.1.0.yml
+++ b/definitions/EiffelTestSuiteFinishedEvent/3.1.0.yml
@@ -150,20 +150,20 @@ _links:
         - EiffelTestSuiteStartedEvent
 _history:
   - version: 3.1.0
-    introduced_in: Current version
+    introduced_in: edition-lyon
     changes: Add `data.persistentLogs.{mediaType,tags}`.
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestSuiteFinishedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestSuiteFinishedEvent/3.2.0.yml
+++ b/definitions/EiffelTestSuiteFinishedEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestSuiteFinishedEvent/3.2.0.yml
+++ b/definitions/EiffelTestSuiteFinishedEvent/3.2.0.yml
@@ -150,24 +150,24 @@ _links:
         - EiffelTestSuiteStartedEvent
 _history:
   - version: 3.2.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.1.0
-    introduced_in: No edition set
+    introduced_in: edition-lyon
     changes: Add `data.persistentLogs.{mediaType,tags}`.
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestSuiteFinishedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestSuiteFinishedEvent/3.3.0.yml
+++ b/definitions/EiffelTestSuiteFinishedEvent/3.3.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestSuiteFinishedEvent/3.3.0.yml
+++ b/definitions/EiffelTestSuiteFinishedEvent/3.3.0.yml
@@ -150,27 +150,27 @@ _links:
         - EiffelTestSuiteStartedEvent
 _history:
   - version: 3.3.0
-    introduced_in: '[edition-arica](../../../tree/edition-arica)'
+    introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
   - version: 3.2.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.1.0
-    introduced_in: No edition set
+    introduced_in: edition-lyon
     changes: Add `data.persistentLogs.{mediaType,tags}`.
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestSuiteFinishedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestSuiteStartedEvent/1.0.0.yml
+++ b/definitions/EiffelTestSuiteStartedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestSuiteStartedEvent/1.0.0.yml
+++ b/definitions/EiffelTestSuiteStartedEvent/1.0.0.yml
@@ -144,7 +144,7 @@ _links:
         - EiffelTestExecutionRecipeCollectionCreatedEvent
 _history:
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestSuiteStartedEvent/1.1.0.yml
+++ b/definitions/EiffelTestSuiteStartedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestSuiteStartedEvent/1.1.0.yml
+++ b/definitions/EiffelTestSuiteStartedEvent/1.1.0.yml
@@ -144,10 +144,10 @@ _links:
         - EiffelTestExecutionRecipeCollectionCreatedEvent
 _history:
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestSuiteStartedEvent/2.0.0.yml
+++ b/definitions/EiffelTestSuiteStartedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestSuiteStartedEvent/2.0.0.yml
+++ b/definitions/EiffelTestSuiteStartedEvent/2.0.0.yml
@@ -144,14 +144,14 @@ _links:
         - EiffelTestExecutionRecipeCollectionCreatedEvent
 _history:
   - version: 2.0.0
-    introduced_in: Current version
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestSuiteStartedEvent/3.0.0.yml
+++ b/definitions/EiffelTestSuiteStartedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestSuiteStartedEvent/3.0.0.yml
+++ b/definitions/EiffelTestSuiteStartedEvent/3.0.0.yml
@@ -144,17 +144,17 @@ _links:
         - EiffelTestExecutionRecipeCollectionCreatedEvent
 _history:
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestSuiteStartedEvent.md)'
+    introduced_in: edition-lyon
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestSuiteStartedEvent/3.1.0.yml
+++ b/definitions/EiffelTestSuiteStartedEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestSuiteStartedEvent/3.1.0.yml
+++ b/definitions/EiffelTestSuiteStartedEvent/3.1.0.yml
@@ -157,20 +157,20 @@ _links:
         - EiffelTestExecutionRecipeCollectionCreatedEvent
 _history:
   - version: 3.1.0
-    introduced_in: Current version
+    introduced_in: edition-lyon
     changes: Add `data.liveLogs.{mediaType,tags}`.
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestSuiteStartedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestSuiteStartedEvent/3.2.0.yml
+++ b/definitions/EiffelTestSuiteStartedEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestSuiteStartedEvent/3.2.0.yml
+++ b/definitions/EiffelTestSuiteStartedEvent/3.2.0.yml
@@ -171,24 +171,24 @@ _links:
         - EiffelTestExecutionRecipeCollectionCreatedEvent
 _history:
   - version: 3.2.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.1.0
-    introduced_in: No edition set
+    introduced_in: edition-lyon
     changes: Add `data.liveLogs.{mediaType,tags}`.
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestSuiteStartedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/definitions/EiffelTestSuiteStartedEvent/3.3.0.yml
+++ b/definitions/EiffelTestSuiteStartedEvent/3.3.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2023 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/definitions/EiffelTestSuiteStartedEvent/3.3.0.yml
+++ b/definitions/EiffelTestSuiteStartedEvent/3.3.0.yml
@@ -171,27 +171,27 @@ _links:
         - EiffelTestExecutionRecipeCollectionCreatedEvent
 _history:
   - version: 3.3.0
-    introduced_in: '[edition-arica](../../../tree/edition-arica)'
+    introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
   - version: 3.2.0
-    introduced_in: '[edition-lyon](../../../tree/edition-lyon)'
+    introduced_in: edition-lyon
     changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
   - version: 3.1.0
-    introduced_in: No edition set
+    introduced_in: edition-lyon
     changes: Add `data.liveLogs.{mediaType,tags}`.
   - version: 3.0.0
-    introduced_in: '[edition-agen](../../../tree/edition-agen)'
+    introduced_in: edition-agen
     changes: Improved information integrity protection (see [Issue
       185](https://github.com/eiffel-community/eiffel/issues/185)).
   - version: 2.0.0
-    introduced_in: '[dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestSuiteStartedEvent.md)'
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0
-    introduced_in: '[edition-toulouse](../../../tree/edition-toulouse)'
+    introduced_in: edition-toulouse
     changes: Multiple links of type FLOW_CONTEXT allowed.
   - version: 1.0.0
-    introduced_in: '[edition-bordeaux](../../../tree/edition-bordeaux)'
+    introduced_in: edition-bordeaux
     changes: Initial version.
 _examples:
   - title: Simple example

--- a/eiffel-syntax-and-usage/event-schemas.md
+++ b/eiffel-syntax-and-usage/event-schemas.md
@@ -36,7 +36,7 @@ Both schemas and documentation files are generated from _schema definition files
 | `_links.<link type>.targets.types`     | A string array of event names that the link type may point to. Must be non-empty if `any_type` is false, and must be empty if `any_type` is true. |
 | `_history`      | An array of objects describing the event type's version history, up to and including the current version. The items should be sorted in reverse order. |
 | `_history.version`        | The event version described in this item. |
-| `_history.introduced_in`  | The first edition in which this version was the latest for this event type. If the version hasn't been released in a protocol edition or if there are newer versions in the first edition where it was introduced, use "No edition set". |
+| `_history.introduced_in`  | The Git tag of the first edition where this version was available, or null if the version hasn't been released in a protocol edition. |
 | `_history.changes`        | A short description of the changes in this item's event version. | 
 | `_examples`     | An array of objects describing examples of this event. |
 | `_examples.title`         | The name of the example. |

--- a/eiffel-vocabulary/EiffelActivityCanceledEvent.md
+++ b/eiffel-vocabulary/EiffelActivityCanceledEvent.md
@@ -179,7 +179,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 | 3.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |
-| 2.0.0 | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelActivityCanceledEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
+| 2.0.0 | [edition-agen](../../../tree/edition-agen) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0 | [edition-toulouse](../../../tree/edition-toulouse) | Multiple links of type FLOW_CONTEXT allowed. |
 | 1.0.0 | [edition-bordeaux](../../../tree/edition-bordeaux) | Initial version. |
 

--- a/eiffel-vocabulary/EiffelActivityFinishedEvent.md
+++ b/eiffel-vocabulary/EiffelActivityFinishedEvent.md
@@ -220,9 +220,9 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 | ------- | ------------- | ------- |
 | 3.3.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.2.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
-| 3.1.0 | No edition set | Add `data.persistentLogs.{mediaType,tags}`. |
+| 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add `data.persistentLogs.{mediaType,tags}`. |
 | 3.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |
-| 2.0.0 | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelActivityFinishedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
+| 2.0.0 | [edition-agen](../../../tree/edition-agen) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0 | [edition-toulouse](../../../tree/edition-toulouse) | Multiple links of type FLOW_CONTEXT allowed. |
 | 1.0.0 | [edition-bordeaux](../../../tree/edition-bordeaux) | Initial version. |
 

--- a/eiffel-vocabulary/EiffelActivityStartedEvent.md
+++ b/eiffel-vocabulary/EiffelActivityStartedEvent.md
@@ -209,10 +209,10 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 | ------- | ------------- | ------- |
 | 4.3.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 4.2.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
-| 4.1.0 | No edition set | Add `data.liveLogs.{mediaType,tags}`. |
+| 4.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add `data.liveLogs.{mediaType,tags}`. |
 | 4.0.0 | [edition-agen-1](../../../tree/edition-agen-1) | Bug fix in schema file (see [Issue 205](https://github.com/eiffel-community/eiffel/issues/205)) |
 | 3.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)) |
-| 2.0.0 | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelActivityStartedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
+| 2.0.0 | [edition-agen](../../../tree/edition-agen) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0 | [edition-toulouse](../../../tree/edition-toulouse) | Multiple links of type FLOW_CONTEXT allowed. |
 | 1.0.0 | [edition-bordeaux](../../../tree/edition-bordeaux) | Initial version. |
 

--- a/eiffel-vocabulary/EiffelActivityTriggeredEvent.md
+++ b/eiffel-vocabulary/EiffelActivityTriggeredEvent.md
@@ -214,7 +214,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 | 4.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 4.0.0 | [edition-agen-1](../../../tree/edition-agen-1) | Bug fix in schema file (see [Issue 205](https://github.com/eiffel-community/eiffel/issues/205)) |
 | 3.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)) |
-| 2.0.0 | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelActivityTriggeredEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
+| 2.0.0 | [edition-agen](../../../tree/edition-agen) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0 | [edition-toulouse](../../../tree/edition-toulouse) | Multiple links of type FLOW_CONTEXT allowed. |
 | 1.0.0 | [edition-bordeaux](../../../tree/edition-bordeaux) | Initial version. |
 

--- a/eiffel-vocabulary/EiffelAnnouncementPublishedEvent.md
+++ b/eiffel-vocabulary/EiffelAnnouncementPublishedEvent.md
@@ -195,7 +195,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 | 3.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |
-| 2.0.0 | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelAnnouncementPublishedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
+| 2.0.0 | [edition-agen](../../../tree/edition-agen) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0 | [edition-toulouse](../../../tree/edition-toulouse) | Multiple links of type FLOW_CONTEXT allowed. |
 | 1.0.0 | [edition-bordeaux](../../../tree/edition-bordeaux) | Initial version. |
 

--- a/eiffel-vocabulary/EiffelArtifactCreatedEvent.md
+++ b/eiffel-vocabulary/EiffelArtifactCreatedEvent.md
@@ -255,10 +255,10 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
 | 3.3.0 | [edition-arica](../../../tree/edition-arica) | Added data.fileInformation.integrityProtection member (see [Issue 290](https://github.com/eiffel-community/eiffel/issues/290)). |
-| 3.2.0 | No edition set | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
+| 3.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |
-| 2.0.0 | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelArtifactCreatedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
+| 2.0.0 | [edition-agen](../../../tree/edition-agen) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0 | [edition-toulouse](../../../tree/edition-toulouse) | Multiple links of type FLOW_CONTEXT allowed. |
 | 1.0.0 | [edition-bordeaux](../../../tree/edition-bordeaux) | Initial version. |
 

--- a/eiffel-vocabulary/EiffelArtifactDeployedEvent.md
+++ b/eiffel-vocabulary/EiffelArtifactDeployedEvent.md
@@ -195,7 +195,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
-| 0.1.0 | No edition set | Initial version. |
+| 0.1.0 | Not yet released in an edition | Initial version. |
 
 
 ## Examples

--- a/eiffel-vocabulary/EiffelArtifactPublishedEvent.md
+++ b/eiffel-vocabulary/EiffelArtifactPublishedEvent.md
@@ -200,7 +200,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 | 3.2.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.1.0 | [edition-paris](../../../tree/edition-paris) | Added name qualifier for artifact locations (see [Issue 248](https://github.com/eiffel-community/eiffel/issues/248)) |
 | 3.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |
-| 2.0.0 | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelArtifactPublishedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
+| 2.0.0 | [edition-agen](../../../tree/edition-agen) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0 | [edition-toulouse](../../../tree/edition-toulouse) | Multiple links of type FLOW_CONTEXT allowed. |
 | 1.0.0 | [edition-bordeaux](../../../tree/edition-bordeaux) | Initial version. |
 

--- a/eiffel-vocabulary/EiffelArtifactReusedEvent.md
+++ b/eiffel-vocabulary/EiffelArtifactReusedEvent.md
@@ -182,7 +182,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 | 3.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |
-| 2.0.0 | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelArtifactReusedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
+| 2.0.0 | [edition-agen](../../../tree/edition-agen) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0 | [edition-toulouse](../../../tree/edition-toulouse) | Multiple links of type FLOW_CONTEXT allowed. |
 | 1.0.0 | [edition-bordeaux](../../../tree/edition-bordeaux) | Initial version. |
 

--- a/eiffel-vocabulary/EiffelCompositionDefinedEvent.md
+++ b/eiffel-vocabulary/EiffelCompositionDefinedEvent.md
@@ -191,7 +191,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 | 3.2.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.1.0 | [edition-paris](../../../tree/edition-paris) | Added SCC as valid target for ELEMENT links (see [Issue 218](https://github.com/eiffel-community/eiffel/issues/218)) |
 | 3.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |
-| 2.0.0 | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelCompositionDefinedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
+| 2.0.0 | [edition-agen](../../../tree/edition-agen) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0 | [edition-toulouse](../../../tree/edition-toulouse) | Multiple links of type FLOW_CONTEXT allowed. |
 | 1.0.0 | [edition-bordeaux](../../../tree/edition-bordeaux) | Initial version. |
 

--- a/eiffel-vocabulary/EiffelConfidenceLevelModifiedEvent.md
+++ b/eiffel-vocabulary/EiffelConfidenceLevelModifiedEvent.md
@@ -218,11 +218,11 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
-| 3.3.0 | No edition set | Add EiffelArtifactDeployedEvent as legal target type for SUBJECT link (see [Issue 239](https://github.com/eiffel-community/eiffel/issues/239)). |
+| 3.3.0 | Not yet released in an edition | Add EiffelArtifactDeployedEvent as legal target type for SUBJECT link (see [Issue 239](https://github.com/eiffel-community/eiffel/issues/239)). |
 | 3.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |
-| 2.0.0 | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelConfidenceLevelModifiedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
+| 2.0.0 | [edition-agen](../../../tree/edition-agen) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0 | [edition-toulouse](../../../tree/edition-toulouse) | Multiple links of type FLOW_CONTEXT allowed. |
 | 1.0.0 | [edition-bordeaux](../../../tree/edition-bordeaux) | Initial version. |
 

--- a/eiffel-vocabulary/EiffelEnvironmentDefinedEvent.md
+++ b/eiffel-vocabulary/EiffelEnvironmentDefinedEvent.md
@@ -216,9 +216,9 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 | ------- | ------------- | ------- |
 | 3.3.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.2.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
-| 3.1.0 | No edition set | Added RUNTIME_ENVIRONMENT link type. |
+| 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Added RUNTIME_ENVIRONMENT link type. |
 | 3.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |
-| 2.0.0 | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelEnvironmentDefinedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
+| 2.0.0 | [edition-agen](../../../tree/edition-agen) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0 | [edition-toulouse](../../../tree/edition-toulouse) | Multiple links of type FLOW_CONTEXT allowed. |
 | 1.0.0 | [edition-bordeaux](../../../tree/edition-bordeaux) | Initial version. |
 

--- a/eiffel-vocabulary/EiffelFlowContextDefinedEvent.md
+++ b/eiffel-vocabulary/EiffelFlowContextDefinedEvent.md
@@ -195,7 +195,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 | 3.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |
-| 2.0.0 | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelFlowContextDefinedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
+| 2.0.0 | [edition-agen](../../../tree/edition-agen) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0 | [edition-toulouse](../../../tree/edition-toulouse) | Multiple links of type FLOW_CONTEXT allowed. |
 | 1.0.0 | [edition-bordeaux](../../../tree/edition-bordeaux) | Initial version. |
 

--- a/eiffel-vocabulary/EiffelIssueDefinedEvent.md
+++ b/eiffel-vocabulary/EiffelIssueDefinedEvent.md
@@ -206,8 +206,8 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 | 3.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |
-| 2.0.0 | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelIssueDefinedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
-| 1.0.0 | [0706840](../../../blob/070684053ceb1da5fb42d9f0ef21df816961d6bc/eiffel-vocabulary/EiffelIssueDefinedEvent.md) | Initial version |
+| 2.0.0 | [edition-agen](../../../tree/edition-agen) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
+| 1.0.0 | [edition-agen](../../../tree/edition-agen) | Initial version |
 
 
 ## Examples

--- a/eiffel-vocabulary/EiffelIssueVerifiedEvent.md
+++ b/eiffel-vocabulary/EiffelIssueVerifiedEvent.md
@@ -203,12 +203,12 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
-| 4.3.0 | No edition set | Add artifact deployed event as legal IUT target (see [Issue 239](https://github.com/eiffel-community/eiffel/issues/239)). |
+| 4.3.0 | Not yet released in an edition | Add artifact deployed event as legal IUT target (see [Issue 239](https://github.com/eiffel-community/eiffel/issues/239)). |
 | 4.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 4.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 4.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |
-| 3.0.0 | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelIssueVerifiedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
-| 2.0.0 | [0706840](../../../blob/070684053ceb1da5fb42d9f0ef21df816961d6bc/eiffel-vocabulary/EiffelIssueVerifiedEvent.md) | Replaced data.issues with links |
+| 3.0.0 | [edition-agen](../../../tree/edition-agen) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
+| 2.0.0 | [edition-agen](../../../tree/edition-agen) | Replaced data.issues with links |
 | 1.1.0 | [edition-toulouse](../../../tree/edition-toulouse) | Multiple links of type FLOW_CONTEXT allowed. |
 | 1.0.0 | [edition-bordeaux](../../../tree/edition-bordeaux) | Initial version. |
 

--- a/eiffel-vocabulary/EiffelSourceChangeCreatedEvent.md
+++ b/eiffel-vocabulary/EiffelSourceChangeCreatedEvent.md
@@ -355,8 +355,8 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 | 4.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 4.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 4.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |
-| 3.0.0 | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelSourceChangeCreatedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
-| 2.0.0 | [0706840](../../../blob/070684053ceb1da5fb42d9f0ef21df816961d6bc/eiffel-vocabulary/EiffelSourceChangeCreatedEvent.md) | Replaced data.issues with links |
+| 3.0.0 | [edition-agen](../../../tree/edition-agen) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
+| 2.0.0 | [edition-agen](../../../tree/edition-agen) | Replaced data.issues with links |
 | 1.1.0 | [edition-toulouse](../../../tree/edition-toulouse) | Multiple links of type FLOW_CONTEXT allowed. |
 | 1.0.0 | [edition-bordeaux](../../../tree/edition-bordeaux) | Initial version. |
 

--- a/eiffel-vocabulary/EiffelSourceChangeSubmittedEvent.md
+++ b/eiffel-vocabulary/EiffelSourceChangeSubmittedEvent.md
@@ -304,7 +304,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 | 3.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |
-| 2.0.0 | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelSourceChangeCreatedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
+| 2.0.0 | [edition-agen](../../../tree/edition-agen) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0 | [edition-toulouse](../../../tree/edition-toulouse) | Multiple links of type FLOW_CONTEXT allowed. |
 | 1.0.0 | [edition-bordeaux](../../../tree/edition-bordeaux) | Initial version. |
 

--- a/eiffel-vocabulary/EiffelTestCaseCanceledEvent.md
+++ b/eiffel-vocabulary/EiffelTestCaseCanceledEvent.md
@@ -179,7 +179,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 | 3.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |
-| 2.0.0 | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestCaseCanceledEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
+| 2.0.0 | [edition-agen](../../../tree/edition-agen) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0 | [edition-toulouse](../../../tree/edition-toulouse) | Multiple links of type FLOW_CONTEXT allowed. |
 | 1.0.0 | [edition-bordeaux](../../../tree/edition-bordeaux) | Initial version. |
 

--- a/eiffel-vocabulary/EiffelTestCaseFinishedEvent.md
+++ b/eiffel-vocabulary/EiffelTestCaseFinishedEvent.md
@@ -247,11 +247,11 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 | ------- | ------------- | ------- |
 | 3.3.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.2.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
-| 3.1.0 | No edition set | Add `data.persistentLogs.{mediaType,tags}`. |
+| 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add `data.persistentLogs.{mediaType,tags}`. |
 | 3.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |
-| 2.0.0 | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestCaseFinishedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
+| 2.0.0 | [edition-agen](../../../tree/edition-agen) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0 | [edition-toulouse](../../../tree/edition-toulouse) | Multiple links of type FLOW_CONTEXT allowed. |
-| 1.0.1 | [0a2f9ef](../../../blob/0a2f9ef139fe6ead2493e5deddf1337ffb3dd4af/eiffel-vocabulary/EiffelTestCaseFinishedEvent.md) | data.outcome.metrics.value and data.outcome.metrics.name made mandatory. |
+| 1.0.1 | [edition-toulouse](../../../tree/edition-toulouse) | data.outcome.metrics.value and data.outcome.metrics.name made mandatory. |
 | 1.0.0 | [edition-bordeaux](../../../tree/edition-bordeaux) | Initial version. |
 
 

--- a/eiffel-vocabulary/EiffelTestCaseStartedEvent.md
+++ b/eiffel-vocabulary/EiffelTestCaseStartedEvent.md
@@ -209,9 +209,9 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 | ------- | ------------- | ------- |
 | 3.3.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.2.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
-| 3.1.0 | No edition set | Add `data.liveLogs.{mediaType,tags}`. |
+| 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add `data.liveLogs.{mediaType,tags}`. |
 | 3.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |
-| 2.0.0 | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestCaseStartedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
+| 2.0.0 | [edition-agen](../../../tree/edition-agen) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0 | [edition-toulouse](../../../tree/edition-toulouse) | Multiple links of type FLOW_CONTEXT allowed. |
 | 1.0.0 | [edition-bordeaux](../../../tree/edition-bordeaux) | Initial version. |
 

--- a/eiffel-vocabulary/EiffelTestCaseTriggeredEvent.md
+++ b/eiffel-vocabulary/EiffelTestCaseTriggeredEvent.md
@@ -251,12 +251,12 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
-| 3.4.0 | No edition set | Add artifact deployed event as legal IUT target (see [Issue 239](https://github.com/eiffel-community/eiffel/issues/239)). |
-| 3.3.0 | No edition set | Add SCS and SCC as legal target for IUT in TCT (see [Issue 317](https://github.com/eiffel-community/eiffel/issues/317)). |
+| 3.4.0 | Not yet released in an edition | Add artifact deployed event as legal IUT target (see [Issue 239](https://github.com/eiffel-community/eiffel/issues/239)). |
+| 3.3.0 | Not yet released in an edition | Add SCS and SCC as legal target for IUT in TCT (see [Issue 317](https://github.com/eiffel-community/eiffel/issues/317)). |
 | 3.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |
-| 2.0.0 | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestCaseTriggeredEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
+| 2.0.0 | [edition-agen](../../../tree/edition-agen) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0 | [edition-toulouse](../../../tree/edition-toulouse) | Multiple links of type FLOW_CONTEXT allowed. |
 | 1.0.0 | [edition-bordeaux](../../../tree/edition-bordeaux) | Initial version. |
 

--- a/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md
+++ b/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md
@@ -279,13 +279,13 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
 | 4.3.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
-| 4.2.0 | No edition set | Add missing testCase.version member (see [Issue 288](https://github.com/eiffel-community/eiffel/issues/288)). |
+| 4.2.0 | [edition-arica](../../../tree/edition-arica) | Add missing testCase.version member (see [Issue 288](https://github.com/eiffel-community/eiffel/issues/288)). |
 | 4.1.1 | [edition-lyon](../../../tree/edition-lyon) | Add missing validation pattern to links.target member (see [Issue 271](https://github.com/eiffel-community/eiffel/issues/271)). |
-| 4.1.0 | No edition set | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
+| 4.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 4.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |
-| 3.0.0 | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
+| 3.0.0 | [edition-agen](../../../tree/edition-agen) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 2.1.0 | [edition-toulouse](../../../tree/edition-toulouse) | Multiple links of type FLOW_CONTEXT allowed. |
-| 2.0.0 | [f92e001](../../../blob/f92e001c88d1139a62f8ace976958e0a30d8f9c5/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md) | Changed syntax of data.batches.recipes.constraints from an uncontrolled object to a list of key-value pairs to comply with design guidelines. |
+| 2.0.0 | [edition-toulouse](../../../tree/edition-toulouse) | Changed syntax of data.batches.recipes.constraints from an uncontrolled object to a list of key-value pairs to comply with design guidelines. |
 | 1.0.0 | [edition-bordeaux](../../../tree/edition-bordeaux) | Initial version. |
 
 

--- a/eiffel-vocabulary/EiffelTestSuiteFinishedEvent.md
+++ b/eiffel-vocabulary/EiffelTestSuiteFinishedEvent.md
@@ -230,9 +230,9 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 | ------- | ------------- | ------- |
 | 3.3.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.2.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
-| 3.1.0 | No edition set | Add `data.persistentLogs.{mediaType,tags}`. |
+| 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add `data.persistentLogs.{mediaType,tags}`. |
 | 3.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |
-| 2.0.0 | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestSuiteFinishedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
+| 2.0.0 | [edition-agen](../../../tree/edition-agen) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0 | [edition-toulouse](../../../tree/edition-toulouse) | Multiple links of type FLOW_CONTEXT allowed. |
 | 1.0.0 | [edition-bordeaux](../../../tree/edition-bordeaux) | Initial version. |
 

--- a/eiffel-vocabulary/EiffelTestSuiteStartedEvent.md
+++ b/eiffel-vocabulary/EiffelTestSuiteStartedEvent.md
@@ -222,9 +222,9 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 | ------- | ------------- | ------- |
 | 3.3.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.2.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
-| 3.1.0 | No edition set | Add `data.liveLogs.{mediaType,tags}`. |
+| 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add `data.liveLogs.{mediaType,tags}`. |
 | 3.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |
-| 2.0.0 | [dc5ec6f](../../../blob/dc5ec6fb87e293eeffe88fdafe698eec0f5a2c89/eiffel-vocabulary/EiffelTestSuiteStartedEvent.md) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
+| 2.0.0 | [edition-agen](../../../tree/edition-agen) | Introduced purl identifiers instead of GAVs (see [Issue 182](https://github.com/eiffel-community/eiffel/issues/182)) |
 | 1.1.0 | [edition-toulouse](../../../tree/edition-toulouse) | Multiple links of type FLOW_CONTEXT allowed. |
 | 1.0.0 | [edition-bordeaux](../../../tree/edition-bordeaux) | Initial version. |
 

--- a/event_docs.md.j2
+++ b/event_docs.md.j2
@@ -53,8 +53,12 @@ __Description:__ {{ field_data.description }}
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
-{% for item in history -%}
-| {{ item.version }} | {{ item.introduced_in }} | {{ item.changes }} |
+{% for item in history %}
+{%- if item.introduced_in is defined -%}
+| {{ item.version }} | [{{ item.introduced_in }}](../../../tree/{{ item.introduced_in }}) | {{ item.changes }} |
+{% else -%}
+| {{ item.version }} | Not yet released in an edition | {{ item.changes }} |
+{% endif -%}
 {% endfor %}
 
 ## Examples

--- a/releases-and-milestones/release-process.md
+++ b/releases-and-milestones/release-process.md
@@ -31,7 +31,7 @@ When all issues in the scope of the edition have been closed and it's time to ma
 
 1.  Verify that all issues in the [milestone](https://github.com/eiffel-community/eiffel/milestones?state=open) are closed.
 1.  Create a pull request with the following changes (see [PR 277](https://github.com/eiffel-community/eiffel/pull/277) for reference):
-    1.  Change all "No edition set" entries in the release tables of the latest YAML file for each event type to a link to the not yet existing edition tag.
+    1.  Make sure history table entries with a missing `introduced_in` key get one that references the soon-to-be tag for the new edition. You can use [yq](https://mikefarah.gitbook.io/yq/) to identify these files: `for i in definitions/Eiffel*Event/*.yml ; do yq -e '._history | .[] | select(.introduced_in == null)' < $i > /dev/null 2>&1 && echo $i ; done`
     1.  Claim the edition in [versioning.md](../eiffel-syntax-and-usage/versioning.md), including a short summary of the changes in the edition.
     1.  Add an entry for the new edition to [generate_manifest.py](../generate_manifest.py). Unfortunately, this means that CI for the resulting commit won't succeed until the tag has been created (see next step).
 1.  When the pull request has been merged, create and push an "edition-\<name>" annotated tag (use `git tag -a`). The tag comment could include a short version of the included changes to the protocol. Any new major versions of event types should be called out.


### PR DESCRIPTION
### Applicable Issues
Fixes #326
Fixes #327

### Description of the Change
The `introduced_in` field in entries of the history tables has previously only had a well-defined and obvious meaning for event versions that were the latest version in a released edition. To make the files more consistent and easier to maintain we change the field to be the Git tag where the event version was first introduced, or null if the version hasn't been released yet. This also makes the field machine-readable, and we'll render it to a clickable link in the Markdown to the documentation generator.

### Alternate Designs
None.

### Benefits
Easier to understand and maintain the documentation.

### Possible Drawbacks
In some cases the version history tables referenced commit SHA-1s. This change replaces this with edition references which is less granular. Of course, if you want to know exactly which commit introduced the version that is easily available from the git.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
