### PR TITLE
Test history table for edition and version errors

### DIFF
--- a/definitions/EiffelTestSuiteStartedEvent/3.0.0.yml
+++ b/definitions/EiffelTestSuiteStartedEvent/3.0.0.yml
@@ -147,7 +147,7 @@ _history:
     introduced_in: edition-agen
     changes: Improved information integrity protection
   - version: 2.0.0
-    introduced_in: edition-lyon
+    introduced_in: edition-agen
     changes: Introduced purl identifiers instead of GAVs (see [Issue
       182](https://github.com/eiffel-community/eiffel/issues/182))
   - version: 1.1.0

--- a/eiffel-vocabulary/EiffelActivityTriggeredEvent.md
+++ b/eiffel-vocabulary/EiffelActivityTriggeredEvent.md
@@ -216,7 +216,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
-| 4.3.0 | [edition-asdflaksjdfö](../../../tree/edition-asdflaksjdfö) | Add ORIGINAL_TRIGGER link (see [Issue 246](https://github.com/eiffel-community/eiffel/issues/246)). |
+| 4.3.0 | [edition-orizaba](../../../tree/edition-orizaba) | Add ORIGINAL_TRIGGER link (see [Issue 246](https://github.com/eiffel-community/eiffel/issues/246)). |
 | 4.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 4.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 4.0.0 | [edition-agen-1](../../../tree/edition-agen-1) | Bug fix in schema file (see [Issue 205](https://github.com/eiffel-community/eiffel/issues/205)) |

--- a/eiffel-vocabulary/EiffelActivityTriggeredEvent.md
+++ b/eiffel-vocabulary/EiffelActivityTriggeredEvent.md
@@ -216,7 +216,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
-| 4.3.0 | [edition-orizaba](../../../tree/edition-orizaba) | Add ORIGINAL_TRIGGER link (see [Issue 246](https://github.com/eiffel-community/eiffel/issues/246)). |
+| 4.3.0 | [edition-asdflaksjdfö](../../../tree/edition-asdflaksjdfö) | Add ORIGINAL_TRIGGER link (see [Issue 246](https://github.com/eiffel-community/eiffel/issues/246)). |
 | 4.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 4.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 4.0.0 | [edition-agen-1](../../../tree/edition-agen-1) | Bug fix in schema file (see [Issue 205](https://github.com/eiffel-community/eiffel/issues/205)) |

--- a/generate_manifest.py
+++ b/generate_manifest.py
@@ -19,7 +19,8 @@ import re
 import subprocess
 import sys
 from functools import cached_property
-from typing import Dict, Optional
+from typing import Dict
+from typing import Optional
 
 import semver
 from ruamel import yaml
@@ -109,7 +110,11 @@ class Manifest:
             )
             if version_of_previous_edition is None:
                 return event_version <= version_of_current_edition
-            return version_of_previous_edition < event_version <= version_of_current_edition
+            return (
+                version_of_previous_edition
+                < event_version
+                <= version_of_current_edition
+            )
 
 
 def _get_latest_schemas(tag: str) -> Dict[str, str]:

--- a/generate_manifest.py
+++ b/generate_manifest.py
@@ -45,11 +45,11 @@ class Manifest:
 
     def __init__(self, manifest_path: str):
         with open(manifest_path) as file:
-            _raw_event_manifest = yaml.YAML().load(file)
+            raw_event_manifest = yaml.YAML().load(file)
 
         # The manifest file is already sorted, but do we want to count on it?
         self._event_manifest = sorted(
-            _raw_event_manifest, key=lambda _edition: _edition["release_date"]
+            raw_event_manifest, key=lambda _edition: _edition["release_date"]
         )
         self._edition_tag_map = dict()
         for edition in self._event_manifest:

--- a/generate_manifest.py
+++ b/generate_manifest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2023 Axis Communications AB.
+# Copyright 2023 Axis Communications AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -97,13 +97,15 @@ class Manifest:
         previous_edition = self.get_previous_edition_by_tag(edition_tag)
         version_of_current_edition = self.event_version_by_tag(edition_tag, event_name)
         if previous_edition is None:
-            return semver.compare(version_of_current_edition, event_version) == 0
+            return semver.VersionInfo.parse(version_of_current_edition).compare(event_version) == 0
         else:
             version_of_previous_edition = self.event_version_by_tag(previous_edition['tag'], event_name)
             if version_of_previous_edition is None:
                 version_of_previous_edition = "0.0.0"
-            does_not_exceed_current_version = semver.compare(version_of_current_edition, event_version) > -1
-            does_not_subceed_previous_version = semver.compare(event_version, version_of_previous_edition) > -1
+            does_not_exceed_current_version = \
+                semver.VersionInfo.parse(version_of_current_edition).compare(event_version) > -1
+            does_not_subceed_previous_version = \
+                semver.VersionInfo.parse(event_version).compare(version_of_previous_edition) > -1
             return does_not_exceed_current_version and does_not_subceed_previous_version
 
 

--- a/generate_manifest.py
+++ b/generate_manifest.py
@@ -49,11 +49,11 @@ class Manifest:
 
         # The manifest file is already sorted, but do we want to count on it?
         self._event_manifest = sorted(
-            _raw_event_manifest,
-            key=lambda _edition: _edition["release_date"])
+            _raw_event_manifest, key=lambda _edition: _edition["release_date"]
+        )
         self._edition_tag_map = dict()
         for edition in self._event_manifest:
-            self._edition_tag_map[edition['tag']] = edition
+            self._edition_tag_map[edition["tag"]] = edition
 
     def is_edition_tag(self, question_tag: str) -> bool:
         """
@@ -66,14 +66,14 @@ class Manifest:
         """
         Fetches all the tags
         """
-        return [edition['tag'] for edition in self._event_manifest]
+        return [edition["tag"] for edition in self._event_manifest]
 
     def event_version_by_tag(self, edition: str, event: str):
         """
         Fetches the event version of the given event in the given edition
         :return: None if event not part of edition
         """
-        return self._edition_tag_map[edition]['events'].get(event, None)
+        return self._edition_tag_map[edition]["events"].get(event, None)
 
     def get_previous_edition_by_tag(self, edition_tag: str):
         """
@@ -97,15 +97,30 @@ class Manifest:
         previous_edition = self.get_previous_edition_by_tag(edition_tag)
         version_of_current_edition = self.event_version_by_tag(edition_tag, event_name)
         if previous_edition is None:
-            return semver.VersionInfo.parse(version_of_current_edition).compare(event_version) == 0
+            return (
+                semver.VersionInfo.parse(version_of_current_edition).compare(
+                    event_version
+                )
+                == 0
+            )
         else:
-            version_of_previous_edition = self.event_version_by_tag(previous_edition['tag'], event_name)
+            version_of_previous_edition = self.event_version_by_tag(
+                previous_edition["tag"], event_name
+            )
             if version_of_previous_edition is None:
                 version_of_previous_edition = "0.0.0"
-            does_not_exceed_current_version = \
-                semver.VersionInfo.parse(version_of_current_edition).compare(event_version) > -1
-            does_not_subceed_previous_version = \
-                semver.VersionInfo.parse(event_version).compare(version_of_previous_edition) > -1
+            does_not_exceed_current_version = (
+                semver.VersionInfo.parse(version_of_current_edition).compare(
+                    event_version
+                )
+                > -1
+            )
+            does_not_subceed_previous_version = (
+                semver.VersionInfo.parse(event_version).compare(
+                    version_of_previous_edition
+                )
+                > -1
+            )
             return does_not_exceed_current_version and does_not_subceed_previous_version
 
 
@@ -116,7 +131,7 @@ def _get_latest_schemas(tag: str) -> Dict[str, str]:
     schema_file_regexp = re.compile(r"^schemas/([^/]+)/([^/]+).json$")
     latest = {}
     for schema_file in subprocess.check_output(
-            ["git", "ls-tree", "-r", "--name-only", tag, "--", "schemas"]
+        ["git", "ls-tree", "-r", "--name-only", tag, "--", "schemas"]
     ).splitlines():
         match = schema_file_regexp.search(schema_file.decode("utf-8"))
         if not match:

--- a/generate_manifest.py
+++ b/generate_manifest.py
@@ -101,7 +101,7 @@ class Manifest:
         previous_edition = self.get_previous_edition_by_tag(edition_tag)
         version_of_current_edition = self.event_version_by_tag(edition_tag, event_name)
         if previous_edition is None:
-            return event_version == version_of_current_edition
+            return event_version <= version_of_current_edition
 
         else:
             version_of_previous_edition = self.event_version_by_tag(

--- a/test_definitions.py
+++ b/test_definitions.py
@@ -14,12 +14,14 @@
 # limitations under the License.
 
 import pathlib
+
 import pytest
+
 import definition_loader
 import generate_manifest
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def manifest():
     return generate_manifest.Manifest("event_manifest.yml")
 
@@ -50,8 +52,9 @@ def test_history_table_contains_valid_release(event_definition_path, manifest):
     for entry in definition.get("_history", []):
         edition = entry.get("introduced_in", None)
         if edition is not None:
-            assert manifest.is_edition_tag(edition), \
-                f"Nonexistent edition '{edition}' in history table for {event_type} {event_version}"
+            assert manifest.is_edition_tag(
+                edition
+            ), f"Nonexistent edition '{edition}' in history table for {event_type} {event_version}"
 
 
 @pytest.mark.parametrize(
@@ -66,5 +69,6 @@ def test_history_table_matches_manifest(event_definition_path, manifest):
         edition = entry.get("introduced_in", None)
         event_version_of_edition = entry.get("version")
         if edition is not None:
-            assert manifest.is_in_edition(edition, event_type, event_version_of_edition), \
-                f"{event_version_of_edition} not part of '{edition}' as describe in history table for {event_type} {event_version}"
+            assert manifest.is_in_edition(
+                edition, event_type, event_version_of_edition
+            ), f"{event_version_of_edition} not part of '{edition}' as describe in history table for {event_type} {event_version}"

--- a/test_definitions.py
+++ b/test_definitions.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Axis Communications AB.
+# Copyright 2023 Axis Communications AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,10 +14,14 @@
 # limitations under the License.
 
 import pathlib
-
 import pytest
-
 import definition_loader
+import generate_manifest
+
+
+@pytest.fixture(scope='session')
+def manifest():
+    return generate_manifest.Manifest("event_manifest.yml")
 
 
 @pytest.mark.parametrize(
@@ -33,3 +37,34 @@ def test_history_table_contains_current_version(event_definition_path):
         for entry in definition.get("_history", [])
         if entry.get("version") == event_version
     ], f"History table entry missing for {event_type} {event_version}"
+
+
+@pytest.mark.parametrize(
+    "event_definition_path",
+    pathlib.Path(".").glob("definitions/Eiffel*Event/*.yml"),
+)
+def test_history_table_contains_valid_release(event_definition_path, manifest):
+    event_type = event_definition_path.parent.name
+    event_version = event_definition_path.stem
+    definition = definition_loader.load(event_definition_path)
+    for entry in definition.get("_history", []):
+        edition = entry.get("introduced_in", None)
+        if edition is not None:
+            assert manifest.is_edition_tag(edition), \
+                f"Nonexistent edition '{edition}' in history table for {event_type} {event_version}"
+
+
+@pytest.mark.parametrize(
+    "event_definition_path",
+    pathlib.Path(".").glob("definitions/Eiffel*Event/*.yml"),
+)
+def test_history_table_matches_manifest(event_definition_path, manifest):
+    event_type = event_definition_path.parent.name
+    event_version = event_definition_path.stem
+    definition = definition_loader.load(event_definition_path)
+    for entry in definition.get("_history", []):
+        edition = entry.get("introduced_in", None)
+        event_version_of_edition = entry.get("version")
+        if edition is not None:
+            assert manifest.is_in_edition(edition, event_type, event_version_of_edition), \
+                f"{event_version_of_edition} not part of '{edition}' as describe in history table for {event_type} {event_version}"

--- a/test_manifest.py
+++ b/test_manifest.py
@@ -1,0 +1,76 @@
+# Copyright 2023 Ericsson AB.
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+
+from generate_manifest import Manifest
+
+
+@pytest.fixture(scope='session')
+def manifest():
+    return Manifest("event_manifest.yml")
+
+
+def test_get_edition_tags(manifest):
+    assert manifest.tags == ['edition-bordeaux',
+                             'edition-toulouse',
+                             'edition-agen',
+                             'edition-agen-1',
+                             'edition-paris',
+                             'edition-lyon',
+                             'edition-arica',
+                             'edition-orizaba']
+
+
+def test_edition_tag(manifest):
+    assert manifest.is_edition_tag('edition-bordeaux') is True
+
+
+def test_not_edition_tag(manifest):
+    assert manifest.is_edition_tag('edition-foo') is False
+
+
+def test_event_version(manifest):
+    assert manifest.event_version_by_tag('edition-agen',
+                                         'EiffelActivityTriggeredEvent') \
+           == "3.0.0"
+
+
+def test_get_previous_edition(manifest):
+    assert manifest.get_previous_edition_by_tag('edition-agen')['tag'] == 'edition-toulouse'
+
+
+def test_get_previous_edition_of_first_edition(manifest):
+    assert manifest.get_previous_edition_by_tag('edition-bordeaux') is None
+
+
+def test_is_event_version_part_of_edition(manifest):
+    assert manifest.is_in_edition('edition-agen', 'EiffelActivityTriggeredEvent', "2.0.0") is True
+    assert manifest.is_in_edition('edition-agen', 'EiffelActivityTriggeredEvent', "3.0.0") is True
+    assert manifest.is_in_edition('edition-agen', 'EiffelActivityTriggeredEvent', "4.0.0") is False
+
+
+def test_is_new_event_version_part_of_edition(manifest):
+    assert manifest.is_in_edition('edition-agen', 'EiffelIssueDefinedEvent', "3.0.0") is True
+
+
+def test_is_event_version_part_of_first_edition(manifest):
+    assert manifest.is_in_edition('edition-bordeaux', 'EiffelActivityTriggeredEvent', "2.0.0") is False
+
+
+def test_is_event_version_part_of_nonexistent_edition(manifest):
+    with pytest.raises(ValueError, match=r".*not found amongst.*"):
+        manifest.is_in_edition('edition-foo', 'EiffelActivityTriggeredEvent', "2.0.0")

--- a/test_manifest.py
+++ b/test_manifest.py
@@ -17,7 +17,7 @@
 import pytest
 
 from generate_manifest import Manifest
-
+from semver import VersionInfo
 
 @pytest.fixture(scope="session")
 def manifest():
@@ -64,6 +64,16 @@ def test_get_previous_edition_of_first_edition(manifest):
 
 
 def test_is_event_version_part_of_edition(manifest):
+    """
+        EiffelActivityTriggeredEvent:
+            - Toulouse: 1.1.0
+            - Agen: 3.0.0
+            - Agen-1: 4.0.0
+    """
+    assert (
+        manifest.is_in_edition("edition-agen", "EiffelActivityTriggeredEvent", "1.0.0")
+        is False
+    )
     assert (
         manifest.is_in_edition("edition-agen", "EiffelActivityTriggeredEvent", "2.0.0")
         is True
@@ -79,6 +89,15 @@ def test_is_event_version_part_of_edition(manifest):
 
 
 def test_is_new_event_version_part_of_edition(manifest):
+    """
+    EiffelIssueDefinedEvent:
+        - Toulouse: Not existing
+        - Agen: 3.0.0
+    """
+    assert (
+        manifest.is_in_edition("edition-agen", "EiffelIssueDefinedEvent", "2.0.0")
+        is True
+    )
     assert (
         manifest.is_in_edition("edition-agen", "EiffelIssueDefinedEvent", "3.0.0")
         is True
@@ -86,6 +105,12 @@ def test_is_new_event_version_part_of_edition(manifest):
 
 
 def test_is_event_version_part_of_first_edition(manifest):
+    assert (
+        manifest.is_in_edition(
+            "edition-bordeaux", "EiffelActivityTriggeredEvent", "0.1.0"
+        )
+        is True
+    )
     assert (
         manifest.is_in_edition(
             "edition-bordeaux", "EiffelActivityTriggeredEvent", "2.0.0"

--- a/test_manifest.py
+++ b/test_manifest.py
@@ -105,9 +105,19 @@ def test_is_new_event_version_part_of_edition(manifest):
 
 
 def test_is_event_version_part_of_first_edition(manifest):
+    """
+    EiffelActivityTriggeredEvent
+        - Bordeaux: 1.0.0
+    """
     assert (
         manifest.is_in_edition(
             "edition-bordeaux", "EiffelActivityTriggeredEvent", "0.1.0"
+        )
+        is True
+    )
+    assert (
+        manifest.is_in_edition(
+            "edition-bordeaux", "EiffelActivityTriggeredEvent", "1.0.0"
         )
         is True
     )

--- a/test_manifest.py
+++ b/test_manifest.py
@@ -17,7 +17,7 @@
 import pytest
 
 from generate_manifest import Manifest
-from semver import VersionInfo
+
 
 @pytest.fixture(scope="session")
 def manifest():
@@ -65,10 +65,10 @@ def test_get_previous_edition_of_first_edition(manifest):
 
 def test_is_event_version_part_of_edition(manifest):
     """
-        EiffelActivityTriggeredEvent:
-            - Toulouse: 1.1.0
-            - Agen: 3.0.0
-            - Agen-1: 4.0.0
+    EiffelActivityTriggeredEvent:
+        - Toulouse: 1.1.0
+        - Agen: 3.0.0
+        - Agen-1: 4.0.0
     """
     assert (
         manifest.is_in_edition("edition-agen", "EiffelActivityTriggeredEvent", "1.0.0")

--- a/test_manifest.py
+++ b/test_manifest.py
@@ -19,58 +19,81 @@ import pytest
 from generate_manifest import Manifest
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def manifest():
     return Manifest("event_manifest.yml")
 
 
 def test_get_edition_tags(manifest):
-    assert manifest.tags == ['edition-bordeaux',
-                             'edition-toulouse',
-                             'edition-agen',
-                             'edition-agen-1',
-                             'edition-paris',
-                             'edition-lyon',
-                             'edition-arica',
-                             'edition-orizaba']
+    assert manifest.tags == [
+        "edition-bordeaux",
+        "edition-toulouse",
+        "edition-agen",
+        "edition-agen-1",
+        "edition-paris",
+        "edition-lyon",
+        "edition-arica",
+        "edition-orizaba",
+    ]
 
 
 def test_edition_tag(manifest):
-    assert manifest.is_edition_tag('edition-bordeaux') is True
+    assert manifest.is_edition_tag("edition-bordeaux") is True
 
 
 def test_not_edition_tag(manifest):
-    assert manifest.is_edition_tag('edition-foo') is False
+    assert manifest.is_edition_tag("edition-foo") is False
 
 
 def test_event_version(manifest):
-    assert manifest.event_version_by_tag('edition-agen',
-                                         'EiffelActivityTriggeredEvent') \
-           == "3.0.0"
+    assert (
+        manifest.event_version_by_tag("edition-agen", "EiffelActivityTriggeredEvent")
+        == "3.0.0"
+    )
 
 
 def test_get_previous_edition(manifest):
-    assert manifest.get_previous_edition_by_tag('edition-agen')['tag'] == 'edition-toulouse'
+    assert (
+        manifest.get_previous_edition_by_tag("edition-agen")["tag"]
+        == "edition-toulouse"
+    )
 
 
 def test_get_previous_edition_of_first_edition(manifest):
-    assert manifest.get_previous_edition_by_tag('edition-bordeaux') is None
+    assert manifest.get_previous_edition_by_tag("edition-bordeaux") is None
 
 
 def test_is_event_version_part_of_edition(manifest):
-    assert manifest.is_in_edition('edition-agen', 'EiffelActivityTriggeredEvent', "2.0.0") is True
-    assert manifest.is_in_edition('edition-agen', 'EiffelActivityTriggeredEvent', "3.0.0") is True
-    assert manifest.is_in_edition('edition-agen', 'EiffelActivityTriggeredEvent', "4.0.0") is False
+    assert (
+        manifest.is_in_edition("edition-agen", "EiffelActivityTriggeredEvent", "2.0.0")
+        is True
+    )
+    assert (
+        manifest.is_in_edition("edition-agen", "EiffelActivityTriggeredEvent", "3.0.0")
+        is True
+    )
+    assert (
+        manifest.is_in_edition("edition-agen", "EiffelActivityTriggeredEvent", "4.0.0")
+        is False
+    )
 
 
 def test_is_new_event_version_part_of_edition(manifest):
-    assert manifest.is_in_edition('edition-agen', 'EiffelIssueDefinedEvent', "3.0.0") is True
+    assert (
+        manifest.is_in_edition("edition-agen", "EiffelIssueDefinedEvent", "3.0.0")
+        is True
+    )
 
 
 def test_is_event_version_part_of_first_edition(manifest):
-    assert manifest.is_in_edition('edition-bordeaux', 'EiffelActivityTriggeredEvent', "2.0.0") is False
+    assert (
+        manifest.is_in_edition(
+            "edition-bordeaux", "EiffelActivityTriggeredEvent", "2.0.0"
+        )
+        is False
+    )
 
 
 def test_is_event_version_part_of_nonexistent_edition(manifest):
     with pytest.raises(ValueError, match=r".*not found amongst.*"):
-        manifest.is_in_edition('edition-foo', 'EiffelActivityTriggeredEvent', "2.0.0")
+        manifest.is_in_edition("edition-foo", "EiffelActivityTriggeredEvent", "2.0.0")


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues

<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
None

### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->

With the introduction of our event definitions as YAML files, it has enabled us
to generate a manifest file. This has in turn enabled us now to test our
documentation against the manifest. This PR introduces:

- test checking that the edition names in our history tables exist in the
  manifest
- Test checking that the specified edition does contain the versions stated
- It fixes an error found with the tests

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

 - Don't know if adding the interface for reading the manifest file should reside
in `generate_manifest.py`, but it felt suitable to have them in one place.
 - Running unittests against a real event manifest file has its drawbacks.

### Benefits

<!-- What benefits will be realized by the change? -->
We can ensure that our history tables contain valid information.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the change? -->
None that I can think of

### Sign-off

<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right
to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my
knowledge, is covered under an appropriate open source license and I have the
right under that license to submit that work with modifications, whether created
in whole or in part by me, under the same open source license (unless I am
permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who
certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and
that a record of the contribution (including all personal information I submit
with it, including my sign-off) is maintained indefinitely and may be
redistributed consistent with this project or the open source license(s)
involved.

Signed-off-by: Mattias Linnér mattias.linner@ericsson.com
