### PR TITLE
Add document related test target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 Axis Communications AB.
+# Copyright 2022-2023 Axis Communications AB and Others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,20 +13,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-.PHONY: all
-all: generate_docs generate_manifest generate_schemas
-
-# The generate_* goals assume that all Python package dependencies are
+# The goals assume that all Python package dependencies are
 # available, e.g. via a virtualenv.
 
+.PHONY: all
+all: generate_docs generate_manifest generate_schemas ## Generate all documentation and schemas from YAML
+
+# Following help file tip from https://stackoverflow.com/questions/8889035/how-to-document-a-makefile
+.PHONY: help
+help:     ## Show this help.
+	 @egrep -h '\s##\s' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m  %-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: tests
+test: ## Run all document related checks found in tox: pytest, jsonformat, validate
+	tox run -e pytest,jsonformat,validate
+
 .PHONY: generate_docs
-generate_docs:
+generate_docs: ## Generate the Markdown files based on the YAML definitions
 	./generate_docs.py definitions/Eiffel*Event/*.yml
 
 .PHONY: generate_manifest
-generate_manifest:
+generate_manifest: ## Generate the manifest file
 	./generate_manifest.py > event_manifest.yml
 
 .PHONY: generate_schemas
-generate_schemas:
+generate_schemas: ## Generate the schemas based on the YAML definitions
 	./generate_schemas.py definitions/Eiffel*Event/*.yml


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues

<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->

None

### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
During the work in https://github.com/eiffel-community/eiffel/pull/366 I wanted to run the documented related tests with a make command. I added that target in that PR, but due to requests, I have moved this change to an own PR.

- Add help target
- Add target to run documented related tests

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

I couldn't think of another good way of doing this.

### Benefits

<!-- What benefits will be realized by the change? -->

Easier to run documented related tests

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the change? -->

None that I can think of


### Sign-off

<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right
to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my
knowledge, is covered under an appropriate open source license and I have the
right under that license to submit that work with modifications, whether created
in whole or in part by me, under the same open source license (unless I am
permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who
certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and
that a record of the contribution (including all personal information I submit
with it, including my sign-off) is maintained indefinitely and may be
redistributed consistent with this project or the open source license(s)
involved.

Signed-off-by: Mattias Linnér mattias.linner@ericsson.com
