### PR TITLE
Update contribution info in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This repository contains the Eiffel protocol vocabulary, descriptions, guides an
 # About this repository
 The contents of this repository are licensed under the [Apache License 2.0](./LICENSE).
 
-To get involved, please see [Code of Conduct](https://github.com/eiffel-community/.github/blob/master/CODE_OF_CONDUCT.md) and [contribution guidelines](https://github.com/eiffel-community/.github/blob/master/CONTRIBUTING.md).
+To get involved, please see [Code of Conduct](https://github.com/eiffel-community/.github/blob/master/CODE_OF_CONDUCT.md) and our [contribution page](https://github.com/eiffel-community/eiffel/contribute).
 
 # About Eiffel
 This repository forms part of the Eiffel Community. Eiffel is a protocol for technology agnostic machine-to-machine communication in continuous integration and delivery pipelines, aimed at securing scalability, flexibility and traceability. Eiffel is based on the concept of decentralized real time messaging, both to drive the continuous integration and delivery system and to document it.


### PR DESCRIPTION
### Applicable Issues
Closes #378 

### Description of the Change
Updates README.md by replacing the direct link to contribution guidelines by a link to the 'contribute' project page.

### Alternate Designs
None

### Benefits
Easier to get started contributing to Eiffel spec repo

### Possible Drawbacks
One more click to find the contrib guidelines

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Emil Bäckmark, emil.backmark@ericsson.com