### PR TITLE
Add JSON schema link validations

### DIFF
--- a/definitions/EiffelActivityCanceledEvent/5.0.0.yml
+++ b/definitions/EiffelActivityCanceledEvent/5.0.0.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-$schema: https://json-schema.org/draft/draft-2020-12/schema#
+$schema: https://json-schema.org/draft/2020-12/schema#
 _name: EiffelActivityCanceledEvent
 _version: 5.0.0
 _abbrev: ActC
@@ -103,7 +103,7 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 5.0.0
-    changes: Update meta schema to Draft 2020-12.
+    changes: Update meta schema to Draft 2020-12 and add link validation.
   - version: 4.0.0
     changes: Fix bug in schema regarding additionalProperties (see [Issue 376](https://github.com/eiffel-community/eiffel/issues/376)).
   - version: 3.2.0

--- a/definitions/EiffelActivityCanceledEvent/5.0.0.yml
+++ b/definitions/EiffelActivityCanceledEvent/5.0.0.yml
@@ -1,0 +1,131 @@
+# Copyright 2017-2024 Ericsson AB and others.
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+$schema: https://json-schema.org/draft/draft-2020-12/schema#
+_name: EiffelActivityCanceledEvent
+_version: 5.0.0
+_abbrev: ActC
+_description: The EiffelActivityCanceledEvent signals that a previously
+  triggered activity execution has been canceled _before it has started_.
+  This is typically used in queuing situations where a queued execution
+  is dequeued. It is recommended that __CAUSE__ links be used to indicate
+  the reason.
+type: object
+properties:
+  meta:
+    $ref: ../EiffelMetaProperty/4.0.0.yml
+  data:
+    type: object
+    properties:
+      reason:
+        _description: Any human readable information as to the reason
+          for dequeueing.
+        type: string
+      customData:
+        type: array
+        items:
+          $ref: ../EiffelCustomDataProperty/2.0.0.yml
+    additionalProperties: false
+  links:
+    type: array
+    contains:
+      type: object
+      properties:
+        type:
+          enum:
+            - ACTIVITY_EXECUTION
+    items:
+      $ref: ../EiffelEventLink/2.0.0.yml
+required:
+  - meta
+  - data
+  - links
+additionalProperties: false
+_links:
+  ACTIVITY_EXECUTION:
+    description: Declares the activity execution that was canceled.
+      In other words, [EiffelActivityTriggeredEvent](../eiffel-vocabulary/EiffelActivityTriggeredEvent.md)
+      acts as a handle for the activity execution. This differs from
+      __CONTEXT__. In __ACTIVITY_EXECUTION__ the source carries information
+      pertaining to the target (i.e. the activity started, finished
+      or was canceled). In __CONTEXT__, on the other hand, the source
+      constitutes a subset of the target (e.g. this test case was executed
+      as part of that activity or test suite).
+    required: true
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelActivityTriggeredEvent
+  CAUSE:
+    description: While for most events it is recommended that __CAUSE__
+      SHOULD not be used in conjunction with __CONTEXT__, EiffelActivityCanceledEvent
+      is a special case as it represents a deviation from previous
+      intention. Therefore it is recommended that __CAUSE__ always
+      be included where applicable.
+    required: false
+    multiple: true
+    targets:
+      any_type: true
+      types: []
+  CONTEXT:
+    description: Identifies the activity or test suite of which this
+      event constitutes a part.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelActivityTriggeredEvent
+        - EiffelTestSuiteStartedEvent
+  FLOW_CONTEXT:
+    description: 'Identifies the flow context of the event: which is
+      the continuous integration and delivery flow in which this occurred
+      – e.g. which product, project, track or version this is applicable
+      to.'
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelFlowContextDefinedEvent
+_history:
+  - version: 5.0.0
+    changes: Update meta schema to Draft 2020-12.
+  - version: 4.0.0
+    changes: Fix bug in schema regarding additionalProperties (see [Issue 376](https://github.com/eiffel-community/eiffel/issues/376)).
+  - version: 3.2.0
+    introduced_in: edition-arica
+    changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
+  - version: 3.1.0
+    introduced_in: edition-lyon
+    changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
+  - version: 3.0.0
+    introduced_in: edition-agen
+    changes: Improved information integrity protection (see [Issue
+      185](https://github.com/eiffel-community/eiffel/issues/185)).
+  - version: 2.0.0
+    introduced_in: edition-agen
+    changes: Introduced purl identifiers instead of GAVs (see [Issue
+      182](https://github.com/eiffel-community/eiffel/issues/182))
+  - version: 1.1.0
+    introduced_in: edition-toulouse
+    changes: Multiple links of type FLOW_CONTEXT allowed.
+  - version: 1.0.0
+    introduced_in: edition-bordeaux
+    changes: Initial version.
+_examples:
+  - title: Simple example
+    url: ../examples/events/EiffelActivityCanceledEvent/simple.json

--- a/definitions/EiffelActivityFinishedEvent/4.0.0.yml
+++ b/definitions/EiffelActivityFinishedEvent/4.0.0.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-$schema: https://json-schema.org/draft/draft-2020-12/schema#
+$schema: https://json-schema.org/draft/2020-12/schema#
 _name: EiffelActivityFinishedEvent
 _version: 4.0.0
 _abbrev: ActF
@@ -157,7 +157,7 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 4.0.0
-    changes: Update meta schema to Draft 2020-12.
+    changes: Update meta schema to Draft 2020-12 and add link validation.
   - version: 3.3.0
     introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).

--- a/definitions/EiffelActivityFinishedEvent/4.0.0.yml
+++ b/definitions/EiffelActivityFinishedEvent/4.0.0.yml
@@ -1,0 +1,186 @@
+# Copyright 2017-2024 Ericsson AB and others.
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+$schema: https://json-schema.org/draft/draft-2020-12/schema#
+_name: EiffelActivityFinishedEvent
+_version: 4.0.0
+_abbrev: ActF
+_description: The EiffelActivityFinishedEvent declares that a previously
+  started activity (declared by [EiffelActivityTriggeredEvent](./EiffelActivityTriggeredEvent.md)
+  followed by [EiffelActivityStartedEvent](./EiffelActivityStartedEvent.md))
+  has finished.
+type: object
+properties:
+  meta:
+    $ref: ../EiffelMetaProperty/4.0.0.yml
+  data:
+    type: object
+    properties:
+      outcome:
+        _description: The outcome of the activity.
+        type: object
+        properties:
+          conclusion:
+            _description: |-
+              A terse standardized conclusion of the activity, designed to be machine readable.
+              SUCCESSFUL signifies that the activity was concluded and the outcome matched expectations.  
+              UNSUCCESSFUL signifies that the activity was concluded, but the outcome did not match expectations. To exemplify, a compilation job was successfully invoked, but compilation failed.  
+              FAILED signifies that the activity could not be successfully executed. To exemplify, a compilation could not be invoked, e.g. due to misconfiguration or environment issues.  
+              ABORTED signifies that the activity was aborted before it could be concluded.  
+              TIMED_OUT signifies that the activity did not conclude within the allowed time frame.  
+              INCONCLUSIVE signifies that the outcome of the activity could not be determined.
+            type: string
+            enum:
+              - SUCCESSFUL
+              - UNSUCCESSFUL
+              - FAILED
+              - ABORTED
+              - TIMED_OUT
+              - INCONCLUSIVE
+          description:
+            _description: A verbose description of the activity outcome,
+              designed to provide human readers with further information.
+            type: string
+        required:
+          - conclusion
+      persistentLogs:
+        _description: An array of persistent log files generated during
+          execution.
+        type: array
+        items:
+          type: object
+          properties:
+            mediaType:
+              _description: The [media type](https://en.wikipedia.org/wiki/Media_type)
+                of the URI's payload. Can be used to differentiate
+                between various representations of the same log, e.g.
+                text/html for human consumption and text/plain or application/json
+                for the machine-readable form.
+              type: string
+            name:
+              _description: The name of the log file.
+              type: string
+            tags:
+              _description: Arbitrary tags and keywords that describe
+                this log.
+              type: array
+              items:
+                type: string
+            uri:
+              _description: The URI at which the log can be retrieved.
+              type: string
+          required:
+            - name
+            - uri
+          additionalProperties: false
+      customData:
+        type: array
+        items:
+          $ref: ../EiffelCustomDataProperty/2.0.0.yml
+    additionalProperties: false
+    required:
+      - outcome
+  links:
+    type: array
+    contains:
+      type: object
+      properties:
+        type:
+          enum:
+            - ACTIVITY_EXECUTION
+    items:
+      $ref: ../EiffelEventLink/2.0.0.yml
+required:
+  - meta
+  - data
+  - links
+additionalProperties: false
+_links:
+  ACTIVITY_EXECUTION:
+    description: Declares the activity execution that was finished.
+      In other words, [EiffelActivityTriggeredEvent](../eiffel-vocabulary/EiffelActivityTriggeredEvent.md)
+      acts as a handle for the activity execution. This differs from
+      __CONTEXT__. In __ACTIVITY_EXECUTION__ the source carries information
+      pertaining to the target (i.e. the activity started, finished
+      or was canceled). In __CONTEXT__, on the other hand, the source
+      constitutes a subset of the target (e.g. this test case was executed
+      as part of that activity or test suite).
+    required: true
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelActivityTriggeredEvent
+  CAUSE:
+    description: 'Identifies a cause of the event occurring. SHOULD
+      not be used in conjunction with __CONTEXT__: individual events
+      providing __CAUSE__ within a larger context gives rise to ambiguity.
+      It is instead recommended to let the root event of the context
+      declare __CAUSE__.'
+    required: false
+    multiple: true
+    targets:
+      any_type: true
+      types: []
+  CONTEXT:
+    description: Identifies the activity or test suite of which this
+      event constitutes a part.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelActivityTriggeredEvent
+        - EiffelTestSuiteStartedEvent
+  FLOW_CONTEXT:
+    description: 'Identifies the flow context of the event: which is
+      the continuous integration and delivery flow in which this occurred
+      – e.g. which product, project, track or version this is applicable
+      to.'
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelFlowContextDefinedEvent
+_history:
+  - version: 4.0.0
+    changes: Update meta schema to Draft 2020-12.
+  - version: 3.3.0
+    introduced_in: edition-arica
+    changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
+  - version: 3.2.0
+    introduced_in: edition-lyon
+    changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
+  - version: 3.1.0
+    introduced_in: edition-lyon
+    changes: Add `data.persistentLogs.{mediaType,tags}`.
+  - version: 3.0.0
+    introduced_in: edition-agen
+    changes: Improved information integrity protection (see [Issue
+      185](https://github.com/eiffel-community/eiffel/issues/185)).
+  - version: 2.0.0
+    introduced_in: edition-agen
+    changes: Introduced purl identifiers instead of GAVs (see [Issue
+      182](https://github.com/eiffel-community/eiffel/issues/182))
+  - version: 1.1.0
+    introduced_in: edition-toulouse
+    changes: Multiple links of type FLOW_CONTEXT allowed.
+  - version: 1.0.0
+    introduced_in: edition-bordeaux
+    changes: Initial version.
+_examples:
+  - title: Simple example
+    url: ../examples/events/EiffelActivityFinishedEvent/simple.json

--- a/definitions/EiffelActivityStartedEvent/5.0.0.yml
+++ b/definitions/EiffelActivityStartedEvent/5.0.0.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-$schema: https://json-schema.org/draft/draft-2020-12/schema#
+$schema: https://json-schema.org/draft/2020-12/schema#
 _name: EiffelActivityStartedEvent
 _version: 5.0.0
 _abbrev: ActS
@@ -143,7 +143,7 @@ _links:
         - EiffelActivityTriggeredEvent
 _history:
   - version: 5.0.0
-    changes: Update meta schema to Draft 2020-12.
+    changes: Update meta schema to Draft 2020-12 and add link validation.
   - version: 4.3.0
     introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).

--- a/definitions/EiffelActivityStartedEvent/5.0.0.yml
+++ b/definitions/EiffelActivityStartedEvent/5.0.0.yml
@@ -1,0 +1,175 @@
+# Copyright 2017-2024 Ericsson AB and others.
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+$schema: https://json-schema.org/draft/draft-2020-12/schema#
+_name: EiffelActivityStartedEvent
+_version: 5.0.0
+_abbrev: ActS
+_description: The EiffelActivityStartedEvent declares that a previously
+  triggered activity (declared by [EiffelActivityTriggeredEvent](./EiffelActivityTriggeredEvent.md))
+  has started.
+type: object
+properties:
+  meta:
+    $ref: ../EiffelMetaProperty/4.0.0.yml
+  data:
+    type: object
+    properties:
+      executionUri:
+        _description: Any URI at which further information about the
+          execution may be found; a typical use case is to link a CI
+          server job execution page.
+        type: string
+      liveLogs:
+        _description: An array of live log files available during execution.
+          These shall not be presumed to be stored persistently; in
+          other words, once the activity has finished there is no guarantee
+          that these links are valid. Persistently stored logs shall
+          be (re-)declared by [EiffelActivityFinishedEvent](./EiffelActivityFinishedEvent.md).
+        type: array
+        items:
+          type: object
+          properties:
+            mediaType:
+              _description: The [media type](https://en.wikipedia.org/wiki/Media_type)
+                of the URI's payload. Can be used to differentiate
+                between various representations of the same log, e.g.
+                text/html for human consumption and text/plain or application/json
+                for the machine-readable form.
+              type: string
+            name:
+              _description: The name of the log file.
+              type: string
+            tags:
+              _description: Arbitrary tags and keywords that describe
+                this log.
+              type: array
+              items:
+                type: string
+            uri:
+              _description: The URI at which the log can be retrieved.
+              type: string
+          required:
+            - name
+            - uri
+          additionalProperties: false
+      customData:
+        type: array
+        items:
+          $ref: ../EiffelCustomDataProperty/2.0.0.yml
+    additionalProperties: false
+  links:
+    type: array
+    contains:
+      type: object
+      properties:
+        type:
+          enum:
+            - ACTIVITY_EXECUTION
+    items:
+      $ref: ../EiffelEventLink/2.0.0.yml
+required:
+  - meta
+  - data
+  - links
+additionalProperties: false
+_links:
+  ACTIVITY_EXECUTION:
+    description: Declares the activity execution that was started.
+      In other words, [EiffelActivityTriggeredEvent](../eiffel-vocabulary/EiffelActivityTriggeredEvent.md)
+      acts as a handle for the activity execution. This differs from
+      __CONTEXT__. In __ACTIVITY_EXECUTION__ the source carries information
+      pertaining to the target (i.e. the activity started, finished
+      or was canceled). In __CONTEXT__, on the other hand, the source
+      constitutes a subset of the target (e.g. this test case was executed
+      as part of that activity or test suite).
+    required: true
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelActivityTriggeredEvent
+  CAUSE:
+    description: 'Identifies a cause of the event occurring. SHOULD
+      not be used in conjunction with __CONTEXT__: individual events
+      providing __CAUSE__ within a larger context gives rise to ambiguity.
+      It is instead recommended to let the root event of the context
+      declare __CAUSE__.'
+    required: false
+    multiple: true
+    targets:
+      any_type: true
+      types: []
+  CONTEXT:
+    description: Identifies the activity or test suite of which this
+      event constitutes a part.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelActivityTriggeredEvent
+        - EiffelTestSuiteStartedEvent
+  FLOW_CONTEXT:
+    description: 'Identifies the flow context of the event: which is
+      the continuous integration and delivery flow in which this occurred
+      – e.g. which product, project, track or version this is applicable
+      to.'
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelFlowContextDefinedEvent
+  PREVIOUS_ACTIVITY_EXECUTION:
+    description: Identifies the latest previous execution of the activity.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelActivityTriggeredEvent
+_history:
+  - version: 5.0.0
+    changes: Update meta schema to Draft 2020-12.
+  - version: 4.3.0
+    introduced_in: edition-arica
+    changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
+  - version: 4.2.0
+    introduced_in: edition-lyon
+    changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
+  - version: 4.1.0
+    introduced_in: edition-lyon
+    changes: Add `data.liveLogs.{mediaType,tags}`.
+  - version: 4.0.0
+    introduced_in: edition-agen-1
+    changes: Bug fix in schema file (see [Issue 205](https://github.com/eiffel-community/eiffel/issues/205))
+  - version: 3.0.0
+    introduced_in: edition-agen
+    changes: Improved information integrity protection (see [Issue
+      185](https://github.com/eiffel-community/eiffel/issues/185))
+  - version: 2.0.0
+    introduced_in: edition-agen
+    changes: Introduced purl identifiers instead of GAVs (see [Issue
+      182](https://github.com/eiffel-community/eiffel/issues/182))
+  - version: 1.1.0
+    introduced_in: edition-toulouse
+    changes: Multiple links of type FLOW_CONTEXT allowed.
+  - version: 1.0.0
+    introduced_in: edition-bordeaux
+    changes: Initial version.
+_examples:
+  - title: Simple example
+    url: ../examples/events/EiffelActivityStartedEvent/simple.json

--- a/definitions/EiffelActivityTriggeredEvent/5.0.0.yml
+++ b/definitions/EiffelActivityTriggeredEvent/5.0.0.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-$schema: https://json-schema.org/draft/draft-2020-12/schema#
+$schema: https://json-schema.org/draft/2020-12/schema#
 _name: EiffelActivityTriggeredEvent
 _version: 5.0.0
 _abbrev: ActT
@@ -156,7 +156,7 @@ _links:
         - EiffelActivityTriggeredEvent
 _history:
   - version: 5.0.0
-    changes: Update meta schema to Draft 2020-12.
+    changes: Update meta schema to Draft 2020-12 and add link validation.
   - version: 4.3.0
     introduced_in: edition-orizaba
     changes: Add ORIGINAL_TRIGGER link (see [Issue 246](https://github.com/eiffel-community/eiffel/issues/246)).

--- a/definitions/EiffelActivityTriggeredEvent/5.0.0.yml
+++ b/definitions/EiffelActivityTriggeredEvent/5.0.0.yml
@@ -1,0 +1,190 @@
+# Copyright 2017-2024 Ericsson AB and others.
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+$schema: https://json-schema.org/draft/draft-2020-12/schema#
+_name: EiffelActivityTriggeredEvent
+_version: 5.0.0
+_abbrev: ActT
+_description: |-
+  The EiffelActivityTriggeredEvent declares that a certain activity - typically a build, test or analysis activity - has been triggered by some factor. Note that this is crucially different from the activity execution having _started_ (as declared by [EiffelActivityStartedEvent](./EiffelActivityStartedEvent.md)).
+
+  In a situation where execution follows immediately upon triggering these two events should be sent together. Where that is not the case (e.g. due to queuing) the time delta between EiffelActivityTriggeredEvent and EiffelActivityStartedEvent constitutes the queue time.
+type: object
+properties:
+  meta:
+    $ref: ../EiffelMetaProperty/4.0.0.yml
+  data:
+    type: object
+    properties:
+      name:
+        _description: The name of the activity. Uniqueness is not required
+          or checked, but is useful.
+        type: string
+      categories:
+        _description: Any categorization of the activity. This can
+          be used to group multiple similar activities for analysis
+          and visualization purposes. Example usage is to label the
+          similar but unique build activities of all the components
+          of system X as "System X Component Build" (whereas the name
+          would be e.g. "System X Component Y Build").
+        type: array
+        items:
+          type: string
+      triggers:
+        _description: The circumstances triggering the activity.
+        type: array
+        items:
+          type: object
+          properties:
+            type:
+              _description: |-
+                The type of trigger.
+                MANUAL signifies that the activity was manually triggered.  
+                EIFFEL_EVENT signifies that the activity was triggered by one or more Eiffel events. These events should be represented via __CAUSE__ links.  
+                SOURCE_CHANGE signifies that the activity was triggered as a consequence of a detected source change __not__ represented by Eiffel events.  
+                TIMER signifies that the activity was triggered by a timer.  
+                OTHER signifies any other triggering cause.
+              type: string
+              enum:
+                - MANUAL
+                - EIFFEL_EVENT
+                - SOURCE_CHANGE
+                - TIMER
+                - OTHER
+            description:
+              _description: A description of the trigger.
+              type: string
+          required:
+            - type
+          additionalProperties: false
+      executionType:
+        _description: The type of execution (often related to, but
+          ultimately separate from, __data.triggers.type__).
+        type: string
+        enum:
+          - MANUAL
+          - SEMI_AUTOMATED
+          - AUTOMATED
+          - OTHER
+      customData:
+        type: array
+        items:
+          $ref: ../EiffelCustomDataProperty/2.0.0.yml
+    required:
+      - name
+    additionalProperties: false
+  links:
+    type: array
+    items:
+      $ref: ../EiffelEventLink/2.0.0.yml
+required:
+  - meta
+  - data
+  - links
+additionalProperties: false
+_links:
+  CAUSE:
+    description: 'Identifies a cause of the event occurring. SHOULD
+      not be used in conjunction with __CONTEXT__: individual events
+      providing __CAUSE__ within a larger context gives rise to ambiguity.
+      It is instead recommended to let the root event of the context
+      declare __CAUSE__.'
+    required: false
+    multiple: true
+    targets:
+      any_type: true
+      types: []
+  CONTEXT:
+    description: 'Identifies the
+      [activity](../eiffel-syntax-and-usage/glossary.md#activity)
+      or test suite of which this event constitutes a part.'
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelActivityTriggeredEvent
+        - EiffelTestSuiteStartedEvent
+  FLOW_CONTEXT:
+    description: 'Identifies the flow context of the event: which is
+      the continuous integration and delivery flow in which this occurred
+      – e.g. which product, project, track or version this is applicable
+      to.'
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelFlowContextDefinedEvent
+  ORIGINAL_TRIGGER:
+    description: 'Used when the current activity is a new attempt at
+      completing a previous activity, typically because the previous one
+      failed. Although this activity may have been manually triggered and
+      thus lacks a cause that can be described with Eiffel, this link can
+      be used to convey the second-order cause.'
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelActivityTriggeredEvent
+  PRECURSOR:
+    description: 'Used to declare temporal relationships between
+      [activities](../eiffel-syntax-and-usage/glossary.md#activity) in a
+      [pipeline](../eiffel-syntax-and-usage/glossary.md#pipeline), i.e. what
+      other activity/activities preceded this activity. This link type applies
+      primarily to non event-triggered activities. For more information on
+      the usage of this link type please see
+      [Activity Linking](../eiffel-syntax-and-usage/activity-linking.md).'
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelActivityTriggeredEvent
+_history:
+  - version: 5.0.0
+    changes: Update meta schema to Draft 2020-12.
+  - version: 4.3.0
+    introduced_in: edition-orizaba
+    changes: Add ORIGINAL_TRIGGER link (see [Issue 246](https://github.com/eiffel-community/eiffel/issues/246)).
+  - version: 4.2.0
+    introduced_in: edition-arica
+    changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
+  - version: 4.1.0
+    introduced_in: edition-lyon
+    changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
+  - version: 4.0.0
+    introduced_in: edition-agen-1
+    changes: Bug fix in schema file (see [Issue 205](https://github.com/eiffel-community/eiffel/issues/205))
+  - version: 3.0.0
+    introduced_in: edition-agen
+    changes: Improved information integrity protection (see [Issue
+      185](https://github.com/eiffel-community/eiffel/issues/185))
+  - version: 2.0.0
+    introduced_in: edition-agen
+    changes: Introduced purl identifiers instead of GAVs (see [Issue
+      182](https://github.com/eiffel-community/eiffel/issues/182))
+  - version: 1.1.0
+    introduced_in: edition-toulouse
+    changes: Multiple links of type FLOW_CONTEXT allowed.
+  - version: 1.0.0
+    introduced_in: edition-bordeaux
+    changes: Initial version.
+_examples:
+  - title: Simple example
+    url: ../examples/events/EiffelActivityTriggeredEvent/simple.json
+  - title: Example containing custom data
+    url: ../examples/events/EiffelActivityTriggeredEvent/simple-customdata.json

--- a/definitions/EiffelAnnouncementPublishedEvent/4.0.0.yml
+++ b/definitions/EiffelAnnouncementPublishedEvent/4.0.0.yml
@@ -1,0 +1,141 @@
+# Copyright 2017-2024 Ericsson AB and others.
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+$schema: https://json-schema.org/draft/draft-2020-12/schema#
+_name: EiffelAnnouncementPublishedEvent
+_version: 4.0.0
+_abbrev: AnnP
+_description: The EiffelAnnouncementPublishedEvent represents an announcement,
+  technically regarding any topic but typically used to communicate
+  any incidents or status updates regarding the continuous integration
+  and delivery pipeline. This information can then be favorably displayed
+  in visualization and dashboarding applications.
+type: object
+properties:
+  meta:
+    $ref: ../EiffelMetaProperty/4.0.0.yml
+  data:
+    type: object
+    properties:
+      heading:
+        _description: The heading of the announcement.
+        type: string
+      body:
+        _description: The body of the announcement.
+        type: string
+      uri:
+        _description: A URI where further information can be obtained,
+          if applicable.
+        type: string
+      severity:
+        _description: The severity of the announcement. The CLOSED
+          and CANCELED values SHOULD only be used when following up
+          a previous announcement, i.e. in conjunction with a __MODIFIED_ANNOUNCEMENT__
+          link.
+        type: string
+        enum:
+          - MINOR
+          - MAJOR
+          - CRITICAL
+          - BLOCKER
+          - CLOSED
+          - CANCELED
+      customData:
+        type: array
+        items:
+          $ref: ../EiffelCustomDataProperty/2.0.0.yml
+    required:
+      - heading
+      - body
+      - severity
+    additionalProperties: false
+  links:
+    type: array
+    items:
+      $ref: ../EiffelEventLink/2.0.0.yml
+required:
+  - meta
+  - data
+  - links
+additionalProperties: false
+_links:
+  CAUSE:
+    description: 'Identifies a cause of the event occurring. SHOULD
+      not be used in conjunction with __CONTEXT__: individual events
+      providing __CAUSE__ within a larger context gives rise to ambiguity.
+      It is instead recommended to let the root event of the context
+      declare __CAUSE__.'
+    required: false
+    multiple: true
+    targets:
+      any_type: true
+      types: []
+  CONTEXT:
+    description: Identifies the activity or test suite of which this
+      event constitutes a part.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelActivityTriggeredEvent
+        - EiffelTestSuiteStartedEvent
+  FLOW_CONTEXT:
+    description: 'Identifies the flow context of the event: which is
+      the continuous integration and delivery flow in which this occurred
+      – e.g. which product, project, track or version this is applicable
+      to.'
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelFlowContextDefinedEvent
+  MODIFIED_ANNOUNCEMENT:
+    description: Identifies an announcement of which this event represents
+      an update or modification, if any. Example usage is to declare
+      the end to a previously announced situation.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelAnnouncementPublishedEvent
+_history:
+  - version: 4.0.0
+    changes: Update meta schema to Draft 2020-12.
+  - version: 3.2.0
+    introduced_in: edition-arica
+    changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
+  - version: 3.1.0
+    introduced_in: edition-lyon
+    changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
+  - version: 3.0.0
+    introduced_in: edition-agen
+    changes: Improved information integrity protection (see [Issue
+      185](https://github.com/eiffel-community/eiffel/issues/185)).
+  - version: 2.0.0
+    introduced_in: edition-agen
+    changes: Introduced purl identifiers instead of GAVs (see [Issue
+      182](https://github.com/eiffel-community/eiffel/issues/182))
+  - version: 1.1.0
+    introduced_in: edition-toulouse
+    changes: Multiple links of type FLOW_CONTEXT allowed.
+  - version: 1.0.0
+    introduced_in: edition-bordeaux
+    changes: Initial version.
+_examples:
+  - title: Simple example
+    url: ../examples/events/EiffelAnnouncementPublishedEvent/simple.json

--- a/definitions/EiffelAnnouncementPublishedEvent/4.0.0.yml
+++ b/definitions/EiffelAnnouncementPublishedEvent/4.0.0.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-$schema: https://json-schema.org/draft/draft-2020-12/schema#
+$schema: https://json-schema.org/draft/2020-12/schema#
 _name: EiffelAnnouncementPublishedEvent
 _version: 4.0.0
 _abbrev: AnnP
@@ -115,7 +115,7 @@ _links:
         - EiffelAnnouncementPublishedEvent
 _history:
   - version: 4.0.0
-    changes: Update meta schema to Draft 2020-12.
+    changes: Update meta schema to Draft 2020-12 and add link validation.
   - version: 3.2.0
     introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).

--- a/definitions/EiffelArtifactCreatedEvent/4.0.0.yml
+++ b/definitions/EiffelArtifactCreatedEvent/4.0.0.yml
@@ -1,0 +1,252 @@
+# Copyright 2017-2024 Ericsson AB and others.
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+$schema: https://json-schema.org/draft/draft-2020-12/schema#
+_name: EiffelArtifactCreatedEvent
+_version: 4.0.0
+_abbrev: ArtC
+_description: The EiffelArtifactCreatedEvent declares that a software
+  artifact has been created, what its coordinates are, what it contains
+  and how it was created.
+type: object
+properties:
+  meta:
+    $ref: ../EiffelMetaProperty/4.0.0.yml
+  data:
+    type: object
+    properties:
+      identity:
+        _description: The identity of the created artifact, in [purl
+          format](https://github.com/package-url/purl-spec).
+        _format: '[purl specification](https://github.com/package-url/purl-spec)'
+        type: string
+        pattern: '^pkg:'
+      fileInformation:
+        _description: A list of the artifact file contents. This information
+          is optional and, when included, MAY include a complete or
+          incomplete list of contents. In other words, it may be used
+          to highlight only particular files of interest, such as launcher
+          binaries or other entry-points.
+        type: array
+        items:
+          type: object
+          properties:
+            name:
+              _description: The name (including relative path from
+                the root of the artifact) on syntax appropriate for
+                the artifact packaging type.
+              type: string
+            tags:
+              _description: Any tags associated with the file, to support
+                navigation and identification of items of interest.
+              type: array
+              items:
+                type: string
+            integrityProtection:
+              _description: An optional object containing a digest of
+                the file's contents, i.e. a checksum, computed using
+                the specified algorithm.
+              type: object
+              properties:
+                alg:
+                  _description: The cryptographic algorithm used to compute
+                    the digest of the file's contents.
+                  _format: One of the hash algorithms listed in section 1 of
+                    [NIST FIPS 180-4](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf),
+                    excluding "SHA-1".
+                  type: string
+                  enum:
+                    - SHA-224
+                    - SHA-256
+                    - SHA-384
+                    - SHA-512
+                    - SHA-512/224
+                    - SHA-512/256
+                digest:
+                  _description: The digest of the file contents.
+                  _format: A lowercase string of hexadecimal digits.
+                  type: string
+                  pattern: ^[0-9a-f]+$
+              required:
+                - alg
+                - digest
+              additionalProperties: false
+          required:
+            - name
+          additionalProperties: false
+      buildCommand:
+        _description: The command used to build the artifact within
+          the identified environment. Used for reproducability purposes.
+        type: string
+      requiresImplementation:
+        _description: |-
+          Defines whether this artifact requires an implementing artifact. This is typically used for interfaces requiring some backend implementation, although the interface does not presume to define _which_ implementation. Implicitly interpreted as "ANY" if undefined.
+          NONE signifies that there SHALL no implementations of this artifact. In other words, a composition containing another artifact identifying it in __data.implements__ would be illegal.  
+          ANY signifies that there may or may not be implementations of this artifact.  
+          EXACTLY_ONE signifies that a legal composition must contain one and only one implementation of this artifact.  
+          AT_LEAST_ONE signifies that a legal composition must contain one or more implementations of this artifact.
+        type: string
+        enum:
+          - NONE
+          - ANY
+          - EXACTLY_ONE
+          - AT_LEAST_ONE
+      dependsOn:
+        _description: An array of [purl identified](https://github.com/package-url/purl-spec)
+          entities this artifact depends on. While not included in
+          the purl specification itself, the Eiffel protocol allows
+          version range notation according to [Maven syntax](https://docs.oracle.com/middleware/1212/core/MAVEN/maven_version.htm#MAVEN402)
+          to be used for the version component of the package identity.
+          Note that the purl specification always requires the version
+          component to be percent-encoded.
+        _format: '[purl specification](https://github.com/package-url/purl-spec)'
+        type: array
+        items:
+          type: string
+          pattern: '^pkg:'
+      implements:
+        _description: An array of [purl identified](https://github.com/package-url/purl-spec)
+          entities this artifact implements. The typical use case of
+          this is to identify interfaces implemented by this artifact.
+          While not included in the purl specification itself, the
+          Eiffel protocol allows version range notation according to
+          [Maven syntax](https://docs.oracle.com/middleware/1212/core/MAVEN/maven_version.htm#MAVEN402)
+          to be used for the version component of the package identity.
+          Note that the purl specification always requires the version
+          component to be percent-encoded.
+        _format: '[purl specification](https://github.com/package-url/purl-spec)'
+        type: array
+        items:
+          type: string
+          pattern: '^pkg:'
+      name:
+        _description: Any (colloquial) name of the artifact. Unlike
+          __data.identity__, this is not intended as an unambiguous
+          identifier of the artifact, but as a descriptive and human
+          readable name.
+        type: string
+      customData:
+        type: array
+        items:
+          $ref: ../EiffelCustomDataProperty/2.0.0.yml
+    required:
+      - identity
+    additionalProperties: false
+  links:
+    type: array
+    items:
+      $ref: ../EiffelEventLink/2.0.0.yml
+required:
+  - meta
+  - data
+  - links
+additionalProperties: false
+_links:
+  CAUSE:
+    description: 'Identifies a cause of the event occurring. SHOULD
+      not be used in conjunction with __CONTEXT__: individual events
+      providing __CAUSE__ within a larger context gives rise to ambiguity.
+      It is instead recommended to let the root event of the context
+      declare __CAUSE__.'
+    required: false
+    multiple: true
+    targets:
+      any_type: true
+      types: []
+  COMPOSITION:
+    description: Identifies the composition from which this artifact
+      was built.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelCompositionDefinedEvent
+  CONTEXT:
+    description: Identifies the activity or test suite of which this
+      event constitutes a part.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelActivityTriggeredEvent
+        - EiffelTestSuiteStartedEvent
+  ENVIRONMENT:
+    description: Identifies the environment in which this artifact
+      was built.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelEnvironmentDefinedEvent
+  FLOW_CONTEXT:
+    description: 'Identifies the flow context of the event: which is
+      the continuous integration and delivery flow in which this occurred
+      – e.g. which product, project, track or version this is applicable
+      to.'
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelFlowContextDefinedEvent
+  PREVIOUS_VERSION:
+    description: Identifies a latest previous version (there may be
+      more than one in case of merges) of the artifact the event represents.
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelArtifactCreatedEvent
+_history:
+  - version: 4.0.0
+    changes: Update meta schema to Draft 2020-12.
+  - version: 3.3.0
+    introduced_in: edition-arica
+    changes: Added data.fileInformation.integrityProtection member (see [Issue 290](https://github.com/eiffel-community/eiffel/issues/290)).
+  - version: 3.2.0
+    introduced_in: edition-arica
+    changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
+  - version: 3.1.0
+    introduced_in: edition-lyon
+    changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
+  - version: 3.0.0
+    introduced_in: edition-agen
+    changes: Improved information integrity protection (see [Issue
+      185](https://github.com/eiffel-community/eiffel/issues/185)).
+  - version: 2.0.0
+    introduced_in: edition-agen
+    changes: Introduced purl identifiers instead of GAVs (see [Issue
+      182](https://github.com/eiffel-community/eiffel/issues/182))
+  - version: 1.1.0
+    introduced_in: edition-toulouse
+    changes: Multiple links of type FLOW_CONTEXT allowed.
+  - version: 1.0.0
+    introduced_in: edition-bordeaux
+    changes: Initial version.
+_examples:
+  - title: Simple example
+    url: ../examples/events/EiffelArtifactCreatedEvent/simple.json
+  - title: Interface example
+    url: ../examples/events/EiffelArtifactCreatedEvent/interface.json
+  - title: Backend example
+    url: ../examples/events/EiffelArtifactCreatedEvent/backend.json
+  - title: Dependent example
+    url: ../examples/events/EiffelArtifactCreatedEvent/dependent.json
+  - title: Checksum example
+    url: ../examples/events/EiffelArtifactCreatedEvent/checksum.json

--- a/definitions/EiffelArtifactCreatedEvent/4.0.0.yml
+++ b/definitions/EiffelArtifactCreatedEvent/4.0.0.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-$schema: https://json-schema.org/draft/draft-2020-12/schema#
+$schema: https://json-schema.org/draft/2020-12/schema#
 _name: EiffelArtifactCreatedEvent
 _version: 4.0.0
 _abbrev: ArtC
@@ -215,7 +215,7 @@ _links:
         - EiffelArtifactCreatedEvent
 _history:
   - version: 4.0.0
-    changes: Update meta schema to Draft 2020-12.
+    changes: Update meta schema to Draft 2020-12 and add link validation.
   - version: 3.3.0
     introduced_in: edition-arica
     changes: Added data.fileInformation.integrityProtection member (see [Issue 290](https://github.com/eiffel-community/eiffel/issues/290)).

--- a/definitions/EiffelArtifactDeployedEvent/0.2.0.yml
+++ b/definitions/EiffelArtifactDeployedEvent/0.2.0.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-$schema: https://json-schema.org/draft/draft-2020-12/schema#
+$schema: https://json-schema.org/draft/2020-12/schema#
 _name: EiffelArtifactDeployedEvent
 _version: 0.2.0
 _abbrev: ArtD
@@ -122,7 +122,7 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 0.2.0
-    changes: Update meta schema to Draft 2020-12.
+    changes: Update meta schema to Draft 2020-12 and add link validation.
   - version: 0.1.0
     introduced_in: edition-orizaba
     changes: Initial version.

--- a/definitions/EiffelArtifactDeployedEvent/0.2.0.yml
+++ b/definitions/EiffelArtifactDeployedEvent/0.2.0.yml
@@ -1,0 +1,131 @@
+# Copyright 2022-2024 Axis Communications AB and others.
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+$schema: https://json-schema.org/draft/draft-2020-12/schema#
+_name: EiffelArtifactDeployedEvent
+_version: 0.2.0
+_abbrev: ArtD
+_description: The EiffelArtifactDeployedEvent states that a software artifact had been deployed into a specified environment or
+  that the configuration of the artifact has been changed.
+  The exact meaning of an artifact deployment is implementation-defined. Progressive deployments like e.g. canaries can be described with an EiffelArtifactDeployedEvent every time the deployment advances or a single EiffelArtifactDeployedEvent once the artifact has been fully deployed.
+type: object
+properties:
+  meta:
+    $ref: ../EiffelMetaProperty/4.0.0.yml
+  data:
+    type: object
+    properties:
+      description:
+        _description: Any human readable information information about this deployment.
+        type: string
+      uri:
+        _description: A URI identifying the deployment description.
+        _format: URI
+        type: string
+      customData:
+        type: array
+        items:
+          $ref: ../EiffelCustomDataProperty/2.0.0.yml
+    additionalProperties: false
+  links:
+    type: array
+    contains:
+      type: object
+      properties:
+        type:
+          enum:
+            - ARTIFACT
+            - ENVIRONMENT
+    items:
+      $ref: ../EiffelEventLink/2.0.0.yml
+required:
+  - meta
+  - data
+  - links
+additionalProperties: false
+_links:
+  ARTIFACT:
+    description: Identifies the artifact that has been deployed.
+    required: true
+    experimental: true
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelArtifactCreatedEvent
+  CAUSE:
+    description: 'Identifies a cause of the event occurring. SHOULD
+      not be used in conjunction with __CONTEXT__: individual events
+      providing __CAUSE__ within a larger context gives rise to ambiguity.
+      It is instead recommended to let the root event of the context
+      declare __CAUSE__.'
+    required: false
+    multiple: true
+    targets:
+      any_type: true
+      types: []
+  CONFIGURATION:
+    description: Identifies the configuration used to deploy the
+      artifact identified with the ARTIFACT link, if the configuration
+      isn't included in the artifact itself. This configuration could be
+      a deployment script, a runbook specification, a helm chart or some
+      other description of how the artifact is started or upgraded in the
+      target environment.
+    required: false
+    experimental: true
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelArtifactCreatedEvent
+  CONTEXT:
+    description: Identifies the activity or test suite of which this
+      event constitutes a part.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelActivityTriggeredEvent
+        - EiffelTestSuiteStartedEvent
+  ENVIRONMENT:
+    description: Identifies the environment into which this artifact
+      was deployed.
+    required: true
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelEnvironmentDefinedEvent
+  FLOW_CONTEXT:
+    description: 'Identifies the flow context of the event: which is
+      the continuous integration and delivery flow in which this occurred
+      – e.g. which product, project, track or version this is applicable
+      to.'
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelFlowContextDefinedEvent
+_history:
+  - version: 0.2.0
+    changes: Update meta schema to Draft 2020-12.
+  - version: 0.1.0
+    introduced_in: edition-orizaba
+    changes: Initial version.
+_examples:
+  - title: Simple example
+    url: ../examples/events/EiffelArtifactDeployedEvent/simple.json

--- a/definitions/EiffelArtifactPublishedEvent/4.0.0.yml
+++ b/definitions/EiffelArtifactPublishedEvent/4.0.0.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-$schema: https://json-schema.org/draft/draft-2020-12/schema#
+$schema: https://json-schema.org/draft/2020-12/schema#
 _name: EiffelArtifactPublishedEvent
 _version: 4.0.0
 _abbrev: ArtP
@@ -127,7 +127,7 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 4.0.0
-    changes: Update meta schema to Draft 2020-12.
+    changes: Update meta schema to Draft 2020-12 and add link validation.
   - version: 3.3.0
     introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).

--- a/definitions/EiffelArtifactPublishedEvent/4.0.0.yml
+++ b/definitions/EiffelArtifactPublishedEvent/4.0.0.yml
@@ -1,0 +1,157 @@
+# Copyright 2017-2024 Ericsson AB and others.
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+$schema: https://json-schema.org/draft/draft-2020-12/schema#
+_name: EiffelArtifactPublishedEvent
+_version: 4.0.0
+_abbrev: ArtP
+_description: The EiffelArtifactPublishedEvent declares that a software
+  artifact (declared by [EiffelArtifactCreatedEvent](./EiffelArtifactCreatedEvent.md))
+  has been published and is consequently available for retrieval at
+  one or more locations.
+type: object
+properties:
+  meta:
+    $ref: ../EiffelMetaProperty/4.0.0.yml
+  data:
+    type: object
+    properties:
+      locations:
+        _description: A list of locations at which the artifact may
+          be retrieved.
+        type: array
+        items:
+          type: object
+          properties:
+            name:
+              _description: Identifies the name of the file within
+                the artifact for which this location provides the URI.
+                Must correspond to a __data.fileInformation.name__
+                value in the [EiffelArtifactCreatedEvent](./EiffelArtifactCreatedEvent.md)
+                connected via the __ARTIFACT__ link.
+              type: string
+            type:
+              _description: |-
+                The type of location. May be used by (automated) readers to understand the method of retrieval, particularly with regards to authentication.
+                ARTIFACTORY signifies an [Artifactory](https://www.jfrog.com/artifactory/)  
+                NEXUS signifies a [Nexus](http://www.sonatype.org/nexus/)  
+                PLAIN signifies a plain HTTP GET request.  
+                OTHER signifies other methods of retrieval. Note that using this type likely requires some foreknowledge on part of the reader in order to fetch the artifact.
+              type: string
+              enum:
+                - ARTIFACTORY
+                - NEXUS
+                - PLAIN
+                - OTHER
+            uri:
+              _description: The URI at which the artifact can be retrieved.
+              type: string
+          required:
+            - type
+            - uri
+          additionalProperties: false
+      customData:
+        type: array
+        items:
+          $ref: ../EiffelCustomDataProperty/2.0.0.yml
+    required:
+      - locations
+    additionalProperties: false
+  links:
+    type: array
+    contains:
+      type: object
+      properties:
+        type:
+          enum:
+            - ARTIFACT
+    items:
+      $ref: ../EiffelEventLink/2.0.0.yml
+required:
+  - meta
+  - data
+  - links
+additionalProperties: false
+_links:
+  ARTIFACT:
+    description: Identifies the artifact that was published.
+    required: true
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelArtifactCreatedEvent
+  CAUSE:
+    description: 'Identifies a cause of the event occurring. SHOULD
+      not be used in conjunction with __CONTEXT__: individual events
+      providing __CAUSE__ within a larger context gives rise to ambiguity.
+      It is instead recommended to let the root event of the context
+      declare __CAUSE__.'
+    required: false
+    multiple: true
+    targets:
+      any_type: true
+      types: []
+  CONTEXT:
+    description: Identifies the activity or test suite of which this
+      event constitutes a part.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelActivityTriggeredEvent
+        - EiffelTestSuiteStartedEvent
+  FLOW_CONTEXT:
+    description: 'Identifies the flow context of the event: which is
+      the continuous integration and delivery flow in which this occurred
+      – e.g. which product, project, track or version this is applicable
+      to.'
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelFlowContextDefinedEvent
+_history:
+  - version: 4.0.0
+    changes: Update meta schema to Draft 2020-12.
+  - version: 3.3.0
+    introduced_in: edition-arica
+    changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
+  - version: 3.2.0
+    introduced_in: edition-lyon
+    changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
+  - version: 3.1.0
+    introduced_in: edition-paris
+    changes: Added name qualifier for artifact locations (see [Issue
+      248](https://github.com/eiffel-community/eiffel/issues/248))
+  - version: 3.0.0
+    introduced_in: edition-agen
+    changes: Improved information integrity protection (see [Issue
+      185](https://github.com/eiffel-community/eiffel/issues/185)).
+  - version: 2.0.0
+    introduced_in: edition-agen
+    changes: Introduced purl identifiers instead of GAVs (see [Issue
+      182](https://github.com/eiffel-community/eiffel/issues/182))
+  - version: 1.1.0
+    introduced_in: edition-toulouse
+    changes: Multiple links of type FLOW_CONTEXT allowed.
+  - version: 1.0.0
+    introduced_in: edition-bordeaux
+    changes: Initial version.
+_examples:
+  - title: Simple example
+    url: ../examples/events/EiffelArtifactPublishedEvent/simple.json

--- a/definitions/EiffelArtifactReusedEvent/4.0.0.yml
+++ b/definitions/EiffelArtifactReusedEvent/4.0.0.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-$schema: https://json-schema.org/draft/draft-2020-12/schema#
+$schema: https://json-schema.org/draft/2020-12/schema#
 _name: EiffelArtifactReusedEvent
 _version: 4.0.0
 _abbrev: ArtR
@@ -103,7 +103,7 @@ _links:
         - EiffelArtifactCreatedEvent
 _history:
   - version: 4.0.0
-    changes: Update meta schema to Draft 2020-12.
+    changes: Update meta schema to Draft 2020-12 and add link validation.
   - version: 3.2.0
     introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).

--- a/definitions/EiffelArtifactReusedEvent/4.0.0.yml
+++ b/definitions/EiffelArtifactReusedEvent/4.0.0.yml
@@ -1,0 +1,129 @@
+# Copyright 2017-2024 Ericsson AB and others.
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+$schema: https://json-schema.org/draft/draft-2020-12/schema#
+_name: EiffelArtifactReusedEvent
+_version: 4.0.0
+_abbrev: ArtR
+_description: |-
+  The EiffelArtifactReusedEvent declares that an identified [EiffelArtifactCreatedEvent](./EiffelArtifactCreatedEvent.md) has been _reused_ for an identified [EiffelCompositionDefinedEvent](./EiffelCompositionDefinedEvent.md). This means that it is logically equivalent to an artifact that would have been built from that composition, and can be used for build avoidance (see the [Build Avoidance Usage Example](../usage-examples/build-avoidance.md) for more information).
+
+  The event has no data members, but solely relies on its two required link types __REUSED_ARTIFACT__ and __COMPOSITION__ (see below).
+type: object
+properties:
+  meta:
+    $ref: ../EiffelMetaProperty/4.0.0.yml
+  data:
+    type: object
+    properties:
+      customData:
+        type: array
+        items:
+          $ref: ../EiffelCustomDataProperty/2.0.0.yml
+    additionalProperties: false
+  links:
+    type: array
+    contains:
+      type: object
+      properties:
+        type:
+          enum:
+            - COMPOSITION
+            - REUSED_ARTIFACT
+    items:
+      $ref: ../EiffelEventLink/2.0.0.yml
+required:
+  - meta
+  - data
+  - links
+additionalProperties: false
+_links:
+  CAUSE:
+    description: 'Identifies a cause of the event occurring. SHOULD
+      not be used in conjunction with __CONTEXT__: individual events
+      providing __CAUSE__ within a larger context gives rise to ambiguity.
+      It is instead recommended to let the root event of the context
+      declare __CAUSE__.'
+    required: false
+    multiple: true
+    targets:
+      any_type: true
+      types: []
+  COMPOSITION:
+    description: Identifies the composition for which an already existing
+      artifact (identified by __REUSED_ARTIFACT__) is declared reused.
+    required: true
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelCompositionDefinedEvent
+  CONTEXT:
+    description: Identifies the activity or test suite of which this
+      event constitutes a part.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelActivityTriggeredEvent
+        - EiffelTestSuiteStartedEvent
+  FLOW_CONTEXT:
+    description: 'Identifies the flow context of the event: which is
+      the continuous integration and delivery flow in which this occurred
+      – e.g. which product, project, track or version this is applicable
+      to.'
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelFlowContextDefinedEvent
+  REUSED_ARTIFACT:
+    description: This link identifies the [EiffelArtifactCreatedEvent](../eiffel-vocabulary/EiffelArtifactCreatedEvent.md)
+      that is reused for the composition identified by __COMPOSITION__;
+      in other words, the artifact that is not rebuilt for a that composition.
+    required: true
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelArtifactCreatedEvent
+_history:
+  - version: 4.0.0
+    changes: Update meta schema to Draft 2020-12.
+  - version: 3.2.0
+    introduced_in: edition-arica
+    changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
+  - version: 3.1.0
+    introduced_in: edition-lyon
+    changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
+  - version: 3.0.0
+    introduced_in: edition-agen
+    changes: Improved information integrity protection (see [Issue
+      185](https://github.com/eiffel-community/eiffel/issues/185)).
+  - version: 2.0.0
+    introduced_in: edition-agen
+    changes: Introduced purl identifiers instead of GAVs (see [Issue
+      182](https://github.com/eiffel-community/eiffel/issues/182))
+  - version: 1.1.0
+    introduced_in: edition-toulouse
+    changes: Multiple links of type FLOW_CONTEXT allowed.
+  - version: 1.0.0
+    introduced_in: edition-bordeaux
+    changes: Initial version.
+_examples:
+  - title: Simple example
+    url: ../examples/events/EiffelArtifactReusedEvent/simple.json

--- a/definitions/EiffelCompositionDefinedEvent/4.0.0.yml
+++ b/definitions/EiffelCompositionDefinedEvent/4.0.0.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-$schema: https://json-schema.org/draft/draft-2020-12/schema#
+$schema: https://json-schema.org/draft/2020-12/schema#
 _name: EiffelCompositionDefinedEvent
 _version: 4.0.0
 _abbrev: CD
@@ -112,7 +112,7 @@ _links:
         - EiffelCompositionDefinedEvent
 _history:
   - version: 4.0.0
-    changes: Update meta schema to Draft 2020-12.
+    changes: Update meta schema to Draft 2020-12 and add link validation.
   - version: 3.3.0
     introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).

--- a/definitions/EiffelCompositionDefinedEvent/4.0.0.yml
+++ b/definitions/EiffelCompositionDefinedEvent/4.0.0.yml
@@ -1,0 +1,142 @@
+# Copyright 2017-2024 Ericsson AB and others.
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+$schema: https://json-schema.org/draft/draft-2020-12/schema#
+_name: EiffelCompositionDefinedEvent
+_version: 4.0.0
+_abbrev: CD
+_description: The EiffelCompositionDefinedEvent declares a composition
+  of items (artifacts, sources and other compositions) has been defined,
+  typically with the purpose of enabling further downstream artifacts
+  to be generated.
+type: object
+properties:
+  meta:
+    $ref: ../EiffelMetaProperty/4.0.0.yml
+  data:
+    type: object
+    properties:
+      name:
+        _description: The name of the composition.
+        type: string
+      version:
+        _description: The version of the composition, if any. This
+          is in a sense redundant, as relationships between compositions
+          can be tracked via the __PREVIOUS_VERSION__ link type, but
+          can be used for improved clarity and semantics.
+        type: string
+      customData:
+        type: array
+        items:
+          $ref: ../EiffelCustomDataProperty/2.0.0.yml
+    required:
+      - name
+    additionalProperties: false
+  links:
+    type: array
+    items:
+      $ref: ../EiffelEventLink/2.0.0.yml
+required:
+  - meta
+  - data
+  - links
+additionalProperties: false
+_links:
+  CAUSE:
+    description: 'Identifies a cause of the event occurring. SHOULD
+      not be used in conjunction with __CONTEXT__: individual events
+      providing __CAUSE__ within a larger context gives rise to ambiguity.
+      It is instead recommended to let the root event of the context
+      declare __CAUSE__.'
+    required: false
+    multiple: true
+    targets:
+      any_type: true
+      types: []
+  CONTEXT:
+    description: Identifies the activity or test suite of which this
+      event constitutes a part.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelActivityTriggeredEvent
+        - EiffelTestSuiteStartedEvent
+  ELEMENT:
+    description: Identifies an element and/or sub-composition of this
+      composition. The latter is particularly useful for documenting
+      large and potentially decentralized compositions, and may be
+      used to reduce the need to repeat large compositions in which
+      only small parts are subject to frequent change.
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelArtifactCreatedEvent
+        - EiffelCompositionDefinedEvent
+        - EiffelSourceChangeCreatedEvent
+        - EiffelSourceChangeSubmittedEvent
+  FLOW_CONTEXT:
+    description: 'Identifies the flow context of the event: which is
+      the continuous integration and delivery flow in which this occurred
+      – e.g. which product, project, track or version this is applicable
+      to.'
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelFlowContextDefinedEvent
+  PREVIOUS_VERSION:
+    description: Identifies a latest previous version (there may be
+      more than one in case of merges) of the composition.
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelCompositionDefinedEvent
+_history:
+  - version: 4.0.0
+    changes: Update meta schema to Draft 2020-12.
+  - version: 3.3.0
+    introduced_in: edition-arica
+    changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
+  - version: 3.2.0
+    introduced_in: edition-lyon
+    changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
+  - version: 3.1.0
+    introduced_in: edition-paris
+    changes: Added SCC as valid target for ELEMENT links (see [Issue
+      218](https://github.com/eiffel-community/eiffel/issues/218))
+  - version: 3.0.0
+    introduced_in: edition-agen
+    changes: Improved information integrity protection (see [Issue
+      185](https://github.com/eiffel-community/eiffel/issues/185)).
+  - version: 2.0.0
+    introduced_in: edition-agen
+    changes: Introduced purl identifiers instead of GAVs (see [Issue
+      182](https://github.com/eiffel-community/eiffel/issues/182))
+  - version: 1.1.0
+    introduced_in: edition-toulouse
+    changes: Multiple links of type FLOW_CONTEXT allowed.
+  - version: 1.0.0
+    introduced_in: edition-bordeaux
+    changes: Initial version.
+_examples:
+  - title: Simple example
+    url: ../examples/events/EiffelCompositionDefinedEvent/simple.json

--- a/definitions/EiffelConfidenceLevelModifiedEvent/4.0.0.yml
+++ b/definitions/EiffelConfidenceLevelModifiedEvent/4.0.0.yml
@@ -1,0 +1,194 @@
+# Copyright 2017-2024 Ericsson AB and others.
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+$schema: https://json-schema.org/draft/draft-2020-12/schema#
+_name: EiffelConfidenceLevelModifiedEvent
+_version: 4.0.0
+_abbrev: CLM
+_description: |-
+  The EiffelConfidenceLevelModifiedEvent declares that an entity has achieved (or failed to achieve) a certain level of confidence, or in a broader sense to annotate it as being applicable or relevant to a certain case (e.g. fit for release to a certain customer segment or having passed certain criteria). This is particularly useful for promoting various engineering artifacts, such as product revisions, through the continuous integration and delivery pipeline.
+
+  Confidence levels may operate at high or low levels of abstraction - ranging from "smokeTestsOk" to "releasable" or "released" - and they may group other confidence levels of lower abstraction levels. They may also be general or very niched, e.g. "releasable" or "releasableToCustomerX". Confidence levels frequently figure in automated delivery interfaces within a tiered system context: lower level tiers issue an agreed confidence level signaling that a new version is ready for integration in a higher level tier.
+type: object
+properties:
+  meta:
+    $ref: ../EiffelMetaProperty/4.0.0.yml
+  data:
+    type: object
+    properties:
+      name:
+        _description: The name of the confidence level. It is recommended
+          for confidence level names to conform with camelCase formatting,
+          in line with the format of key names of the Eiffel protocol
+          as a whole.
+        type: string
+      value:
+        _description: |-
+          The value of the confidence level.
+          SUCCESS signifies that the confidence level has been successfully achieved.  
+          FAILURE signifies that the confidence level could not be achieved.
+          INCONCLUSIVE signifies that achievement of the confidence level could not be determined.
+        type: string
+        enum:
+          - SUCCESS
+          - FAILURE
+          - INCONCLUSIVE
+      issuer:
+        _description: The individual or entity issuing the confidence
+          level.
+        type: object
+        properties:
+          name:
+            _description: The name of the issuer.
+            type: string
+          email:
+            _description: The e-mail address of the issuer.
+            type: string
+          id:
+            _description: Any identity, alias or handle of the issuer,
+              such as a corporate id or username.
+            type: string
+          group:
+            _description: Any group, such as a development team, committee
+              or test group, to which the issuer belongs.
+            type: string
+        additionalProperties: false
+      customData:
+        type: array
+        items:
+          $ref: ../EiffelCustomDataProperty/2.0.0.yml
+    required:
+      - name
+      - value
+    additionalProperties: false
+  links:
+    type: array
+    contains:
+      type: object
+      properties:
+        type:
+          enum:
+            - SUBJECT
+    items:
+      $ref: ../EiffelEventLink/2.0.0.yml
+required:
+  - meta
+  - data
+  - links
+additionalProperties: false
+_links:
+  CAUSE:
+    description: 'Identifies a cause of the event occurring. SHOULD
+      not be used in conjunction with __CONTEXT__: individual events
+      providing __CAUSE__ within a larger context gives rise to ambiguity.
+      It is instead recommended to let the root event of the context
+      declare __CAUSE__.'
+    required: false
+    multiple: true
+    targets:
+      any_type: true
+      types: []
+  CONFIDENCE_BASIS:
+    description: 'Used to declare the basis for which confidence statement(s) this event have used. 
+      The __CAUSE__ link tells what caused the event sending whereas __CONFIDENCE_BASIS__ declares the reason for
+      selecting the provided __data.name__ and/or __data.value__.'
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelConfidenceLevelModifiedEvent
+        - EiffelTestCaseFinishedEvent
+        - EiffelTestSuiteFinishedEvent
+  CONTEXT:
+    description: Identifies the activity or test suite of which this
+      event constitutes a part.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelActivityTriggeredEvent
+        - EiffelTestSuiteStartedEvent
+  FLOW_CONTEXT:
+    description: 'Identifies the flow context of the event: which is
+      the continuous integration and delivery flow in which this occurred
+      – e.g. which product, project, track or version this is applicable
+      to.'
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelFlowContextDefinedEvent
+  SUBJECT:
+    description: Identifies a subject of the confidence level; in other
+      words, what the confidence level applies to.
+    required: true
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelArtifactCreatedEvent
+        - EiffelArtifactDeployedEvent
+        - EiffelCompositionDefinedEvent
+        - EiffelSourceChangeCreatedEvent
+        - EiffelSourceChangeSubmittedEvent
+  SUB_CONFIDENCE_LEVEL:
+    description: 'Used in events summarizing multiple confidence levels.
+      Example use case: the confidence level "allTestsOk" summarizes
+      the confidence levels "unitTestsOk, "scenarioTestsOk" and "deploymentTestsOk",
+      and consequently links to them via __SUB_CONFIDENCE_LEVEL__.
+      This is intended for purely descriptive, rather than prescriptive,
+      use. Future editions might deprecate this link in favour of CONFIDENCE_BASIS.'
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelConfidenceLevelModifiedEvent
+_history:
+  - version: 4.0.0
+    changes: Update meta schema to Draft 2020-12.
+  - version: 3.4.0
+    changes: Add CONFIDENCE_BASIS link (see [Issue 323](https://github.com/eiffel-community/eiffel/issues/323)).
+  - version: 3.3.0
+    introduced_in: edition-orizaba
+    changes: Add EiffelArtifactDeployedEvent as legal target type for
+      SUBJECT link (see
+      [Issue 239](https://github.com/eiffel-community/eiffel/issues/239)).
+  - version: 3.2.0
+    introduced_in: edition-arica
+    changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
+  - version: 3.1.0
+    introduced_in: edition-lyon
+    changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
+  - version: 3.0.0
+    introduced_in: edition-agen
+    changes: Improved information integrity protection (see [Issue
+      185](https://github.com/eiffel-community/eiffel/issues/185)).
+  - version: 2.0.0
+    introduced_in: edition-agen
+    changes: Introduced purl identifiers instead of GAVs (see [Issue
+      182](https://github.com/eiffel-community/eiffel/issues/182))
+  - version: 1.1.0
+    introduced_in: edition-toulouse
+    changes: Multiple links of type FLOW_CONTEXT allowed.
+  - version: 1.0.0
+    introduced_in: edition-bordeaux
+    changes: Initial version.
+_examples:
+  - title: Simple example
+    url: ../examples/events/EiffelConfidenceLevelModifiedEvent/simple.json

--- a/definitions/EiffelConfidenceLevelModifiedEvent/4.0.0.yml
+++ b/definitions/EiffelConfidenceLevelModifiedEvent/4.0.0.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-$schema: https://json-schema.org/draft/draft-2020-12/schema#
+$schema: https://json-schema.org/draft/2020-12/schema#
 _name: EiffelConfidenceLevelModifiedEvent
 _version: 4.0.0
 _abbrev: CLM
@@ -161,7 +161,7 @@ _links:
         - EiffelConfidenceLevelModifiedEvent
 _history:
   - version: 4.0.0
-    changes: Update meta schema to Draft 2020-12.
+    changes: Update meta schema to Draft 2020-12 and add link validation.
   - version: 3.4.0
     changes: Add CONFIDENCE_BASIS link (see [Issue 323](https://github.com/eiffel-community/eiffel/issues/323)).
   - version: 3.3.0

--- a/definitions/EiffelCustomDataProperty/2.0.0.yml
+++ b/definitions/EiffelCustomDataProperty/2.0.0.yml
@@ -1,0 +1,27 @@
+# Copyright 2017-2024 Ericsson AB and others.
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+$schema: https://json-schema.org/draft/draft-2020-12/schema#
+_name: EiffelCustomDataProperty
+_version: 2.0.0
+type: object
+properties:
+  key:
+    type: string
+  value: {}
+required:
+  - key
+  - value
+additionalProperties: false

--- a/definitions/EiffelEnvironmentDefinedEvent/4.0.0.yml
+++ b/definitions/EiffelEnvironmentDefinedEvent/4.0.0.yml
@@ -1,0 +1,185 @@
+# Copyright 2017-2024 Ericsson AB and others.
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+$schema: https://json-schema.org/draft/draft-2020-12/schema#
+_name: EiffelEnvironmentDefinedEvent
+_version: 4.0.0
+_abbrev: ED
+_description: |-
+  The EiffelEnvironmentDefinedEvent declares an environment which may be referenced from other events in order to secure traceability to the conditions under which an artifact was created or a test was executed. Depending on the technology domain, the nature of an environment varies greatly however: it may be a virtual image, a complete mechatronic system of millions of independent parts, or anything in between. Consequently, a concise yet complete and generic syntax for describing any environment is futile.
+
+  From Eiffel's point of view, however, the prioritized concern is not _description_ of the environment, but rather unambiguous _identification_ of it. Consequently, the EiffelEnvironmentDefinedEvent syntax offers several alternatives to be selected from depending on the use case at hand: an environment may be described using __data.image__, __data.host__ or __data.uri__, or a __RUNTIME_ENVIRONMENT__ link to another event that provides a more comprehensive description. Unless a link of the latter kind is used exactly one of these properties SHOULD be included in any one event. In certain situations where an actual description of the environment is deemed redundant or its nature is implicit, the event MAY be used without any of these properties or a RUNTIME_ENVIRONMENT link; it should be noted, however, that _explicit_ practices are always encouraged over _implicit_ ones.
+type: object
+properties:
+  meta:
+    $ref: ../EiffelMetaProperty/4.0.0.yml
+  data:
+    type: object
+    properties:
+      name:
+        _description: The name of the environment.
+        type: string
+      version:
+        _description: The version of the environment, if any. This
+          is in a sense redundant, as relationships between environments
+          can be tracked via the __PREVIOUS_VERSION__ link type, but
+          can be used for improved clarity and semantics.
+        type: string
+      image:
+        _description: A string identifying e.g. a [Docker](https://www.docker.com/)
+          image that defines this environment. Use of this member is
+          discouraged. Prefer using the less ambiguous RUNTIME_ENVIRONMENT
+          link type.
+        type: string
+      host:
+        _description: An object identifying a host. This object is
+          included for pragmatic reasons, as this method of environment
+          identification is often used in practice. It is discouraged,
+          however, as it is highly unreliable both in terms of consistency
+          and traceability. Consistency because consecutive executions
+          on the same host may produce different results, as there
+          are no inherent guarantees that it will stay the same over
+          time. Traceability because when analyzing the historical
+          record you want a static description of the environment _as
+          it was at the time of execution_, not a pointer to a dynamic
+          entity which may or may not have changed since then (and
+          may or may not have changed again the next time you inspect
+          it).
+        type: object
+        properties:
+          name:
+            _description: The hostname.
+            type: string
+          user:
+            _description: The user name on the host.
+            type: string
+        required:
+          - name
+          - user
+        additionalProperties: false
+      uri:
+        _description: A URI identifying the environment description.
+          This is the catch-all method of environment descriptions.
+          Eiffel does not concern itself with the format or nature
+          of the description, but merely points to its location.
+        type: string
+      customData:
+        type: array
+        items:
+          $ref: ../EiffelCustomDataProperty/2.0.0.yml
+    required:
+      - name
+    additionalProperties: false
+  links:
+    type: array
+    items:
+      $ref: ../EiffelEventLink/2.0.0.yml
+required:
+  - meta
+  - data
+  - links
+additionalProperties: false
+_links:
+  CAUSE:
+    description: 'Identifies a cause of the event occurring. SHOULD
+      not be used in conjunction with __CONTEXT__: individual events
+      providing __CAUSE__ within a larger context gives rise to ambiguity.
+      It is instead recommended to let the root event of the context
+      declare __CAUSE__.'
+    required: false
+    multiple: true
+    targets:
+      any_type: true
+      types: []
+  CONTEXT:
+    description: Identifies the activity or test suite of which this
+      event constitutes a part.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelActivityTriggeredEvent
+        - EiffelTestSuiteStartedEvent
+  FLOW_CONTEXT:
+    description: 'Identifies the flow context of the event: which is
+      the continuous integration and delivery flow in which this occurred
+      – e.g. which product, project, track or version this is applicable
+      to.'
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelFlowContextDefinedEvent
+  PREVIOUS_VERSION:
+    description: Identifies a latest previous version (there may be
+      more than one in case of merges) of the environment.
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelEnvironmentDefinedEvent
+  RUNTIME_ENVIRONMENT:
+    description: Identifies a description of a runtime environment
+      within which an activity has taken place. The target event could
+      e.g. identify a [Docker](https://www.docker.com/) image, a JVM
+      distribution archive, or a composition of operating system packages
+      that were installed on the host system. This link type has the
+      same purpose as the `data.image` member but allows richer and
+      less ambiguous descriptions.
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelArtifactCreatedEvent
+        - EiffelCompositionDefinedEvent
+_history:
+  - version: 4.0.0
+    changes: Update meta schema to Draft 2020-12.
+  - version: 3.3.0
+    introduced_in: edition-arica
+    changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
+  - version: 3.2.0
+    introduced_in: edition-lyon
+    changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
+  - version: 3.1.0
+    introduced_in: edition-lyon
+    changes: Added RUNTIME_ENVIRONMENT link type.
+  - version: 3.0.0
+    introduced_in: edition-agen
+    changes: Improved information integrity protection (see [Issue
+      185](https://github.com/eiffel-community/eiffel/issues/185)).
+  - version: 2.0.0
+    introduced_in: edition-agen
+    changes: Introduced purl identifiers instead of GAVs (see [Issue
+      182](https://github.com/eiffel-community/eiffel/issues/182))
+  - version: 1.1.0
+    introduced_in: edition-toulouse
+    changes: Multiple links of type FLOW_CONTEXT allowed.
+  - version: 1.0.0
+    introduced_in: edition-bordeaux
+    changes: Initial version.
+_examples:
+  - title: URI example
+    url: ../examples/events/EiffelEnvironmentDefinedEvent/uri.json
+  - title: Host example
+    url: ../examples/events/EiffelEnvironmentDefinedEvent/host.json
+  - title: Image example
+    url: ../examples/events/EiffelEnvironmentDefinedEvent/image.json
+  - title: RUNTIME_ENVIRONMENT link example
+    url: ../examples/events/EiffelEnvironmentDefinedEvent/runtime-env-link.json

--- a/definitions/EiffelEnvironmentDefinedEvent/4.0.0.yml
+++ b/definitions/EiffelEnvironmentDefinedEvent/4.0.0.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-$schema: https://json-schema.org/draft/draft-2020-12/schema#
+$schema: https://json-schema.org/draft/2020-12/schema#
 _name: EiffelEnvironmentDefinedEvent
 _version: 4.0.0
 _abbrev: ED
@@ -150,7 +150,7 @@ _links:
         - EiffelCompositionDefinedEvent
 _history:
   - version: 4.0.0
-    changes: Update meta schema to Draft 2020-12.
+    changes: Update meta schema to Draft 2020-12 and add link validation.
   - version: 3.3.0
     introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).

--- a/definitions/EiffelEventLink/2.0.0.yml
+++ b/definitions/EiffelEventLink/2.0.0.yml
@@ -1,0 +1,31 @@
+# Copyright 2017-2024 Ericsson AB and others.
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+$schema: https://json-schema.org/draft/draft-2020-12/schema#
+_name: EiffelEventLink
+_version: 2.0.0
+type: object
+properties:
+  type:
+    type: string
+  target:
+    type: string
+    pattern: ^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$
+  domainId:
+    type: string
+required:
+  - type
+  - target
+additionalProperties: false

--- a/definitions/EiffelFlowContextDefinedEvent/4.0.0.yml
+++ b/definitions/EiffelFlowContextDefinedEvent/4.0.0.yml
@@ -1,0 +1,127 @@
+# Copyright 2017-2024 Ericsson AB and others.
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+$schema: https://json-schema.org/draft/draft-2020-12/schema#
+_name: EiffelFlowContextDefinedEvent
+_version: 4.0.0
+_abbrev: FCD
+_description: |-
+  The EiffelFlowContextDefinedEvent describes the context of other events, answering questions such as "Which project is this change part of?" or "Which track does this artifact belong to?". In this way it offers a method of classifying and structuring one's continuous integration and delivery system and thereby facilitating traceability and searchability.
+
+  The nature of the described context can vary. The event consequently offers a high degree of flexibility in its description, and none of its member fields are mandatory. Instead they can picked and mixed to fit the situation.
+type: object
+properties:
+  meta:
+    $ref: ../EiffelMetaProperty/4.0.0.yml
+  data:
+    type: object
+    properties:
+      product:
+        _description: A product context which other events can relate
+          to (e.g. "This activity is part of the Product X continuous
+          integration system.").
+        type: string
+      project:
+        _description: A project context which other events can relate
+          to (e.g. "This test is part of the Killer Feature project.").
+        type: string
+      program:
+        _description: A program context which other events can relate
+          to (e.g. "This source change was made for the Zero Bugs program.").
+        type: string
+      track:
+        _description: A track context which other events can relate
+          to (e.g. "This feature was implemented in the Customer X
+          Adaptations track.").
+        type: string
+      version:
+        _description: A version context which other events can relate
+          to. This member SHOULD be used in tandem with one of the
+          other optional members - a version by itself is not very
+          informative.
+        type: string
+      customData:
+        type: array
+        items:
+          $ref: ../EiffelCustomDataProperty/2.0.0.yml
+    additionalProperties: false
+  links:
+    type: array
+    items:
+      $ref: ../EiffelEventLink/2.0.0.yml
+required:
+  - meta
+  - data
+  - links
+additionalProperties: false
+_links:
+  CAUSE:
+    description: 'Identifies a cause of the event occurring. SHOULD
+      not be used in conjunction with __CONTEXT__: individual events
+      providing __CAUSE__ within a larger context gives rise to ambiguity.
+      It is instead recommended to let the root event of the context
+      declare __CAUSE__.'
+    required: false
+    multiple: true
+    targets:
+      any_type: true
+      types: []
+  CONTEXT:
+    description: Identifies the activity or test suite of which this
+      event constitutes a part.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelActivityTriggeredEvent
+        - EiffelTestSuiteStartedEvent
+  FLOW_CONTEXT:
+    description: 'Identifies the flow context of the event: which is
+      the continuous integration and delivery flow in which this occurred
+      – e.g. which product, project, track or version this is applicable
+      to.'
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelFlowContextDefinedEvent
+_history:
+  - version: 4.0.0
+    changes: Update meta schema to Draft 2020-12.
+  - version: 3.2.0
+    introduced_in: edition-arica
+    changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
+  - version: 3.1.0
+    introduced_in: edition-lyon
+    changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
+  - version: 3.0.0
+    introduced_in: edition-agen
+    changes: Improved information integrity protection (see [Issue
+      185](https://github.com/eiffel-community/eiffel/issues/185)).
+  - version: 2.0.0
+    introduced_in: edition-agen
+    changes: Introduced purl identifiers instead of GAVs (see [Issue
+      182](https://github.com/eiffel-community/eiffel/issues/182))
+  - version: 1.1.0
+    introduced_in: edition-toulouse
+    changes: Multiple links of type FLOW_CONTEXT allowed.
+  - version: 1.0.0
+    introduced_in: edition-bordeaux
+    changes: Initial version.
+_examples:
+  - title: Simple example
+    url: ../examples/events/EiffelFlowContextDefinedEvent/simple.json

--- a/definitions/EiffelFlowContextDefinedEvent/4.0.0.yml
+++ b/definitions/EiffelFlowContextDefinedEvent/4.0.0.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-$schema: https://json-schema.org/draft/draft-2020-12/schema#
+$schema: https://json-schema.org/draft/2020-12/schema#
 _name: EiffelFlowContextDefinedEvent
 _version: 4.0.0
 _abbrev: FCD
@@ -101,7 +101,7 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 4.0.0
-    changes: Update meta schema to Draft 2020-12.
+    changes: Update meta schema to Draft 2020-12 and add link validation.
   - version: 3.2.0
     introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).

--- a/definitions/EiffelIssueDefinedEvent/4.0.0.yml
+++ b/definitions/EiffelIssueDefinedEvent/4.0.0.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-$schema: https://json-schema.org/draft/draft-2020-12/schema#
+$schema: https://json-schema.org/draft/2020-12/schema#
 _name: EiffelIssueDefinedEvent
 _version: 4.0.0
 _abbrev: ID
@@ -116,7 +116,7 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 4.0.0
-    changes: Update meta schema to Draft 2020-12.
+    changes: Update meta schema to Draft 2020-12 and add link validation.
   - version: 3.2.0
     introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).

--- a/definitions/EiffelIssueDefinedEvent/4.0.0.yml
+++ b/definitions/EiffelIssueDefinedEvent/4.0.0.yml
@@ -1,0 +1,139 @@
+# Copyright 2017-2024 Ericsson AB and others.
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+$schema: https://json-schema.org/draft/draft-2020-12/schema#
+_name: EiffelIssueDefinedEvent
+_version: 4.0.0
+_abbrev: ID
+_description: The EiffelIssueDefinedEvent declares that an issue has
+  been created in some external issue management software. ID is semantically
+  similar to
+  [EiffelFlowContextDefinedEvent](../eiffel-vocabulary/EiffelFlowContextDefinedEvent.md) and
+  [EiffelEnvironmentDefinedEvent](../eiffel-vocabulary/EiffelEnvironmentDefinedEvent.md).
+type: object
+properties:
+  meta:
+    $ref: ../EiffelMetaProperty/4.0.0.yml
+  data:
+    type: object
+    properties:
+      type:
+        _description: The type of issue.
+        type: string
+        enum:
+          - BUG
+          - IMPROVEMENT
+          - FEATURE
+          - WORK_ITEM
+          - REQUIREMENT
+          - OTHER
+      tracker:
+        _description: |-
+          The name of the issue tracker. This can unfortunately not be
+          standardized, and is therefore context sensitive: though some trackers and ALM
+          tools are more popular than others, an exhaustive enumeration is impossible,
+          particularly when considering company specific internal solutions. Consequently
+          one should not rely on the name as the primary method of retrieval, but rather
+          __data.uri__. __data.tracker__ together with __data.id__
+          is still useful for analysis and traceability, however, as long as it can be
+          correctly interpreted.
+        type: string
+      id:
+        _description: |-
+          The identity of the issue. This is tracker dependent - most
+          trackers have their own issue naming schemes.
+        type: string
+      uri:
+        _description: A URI that links to a document describing the
+          issue in depth.
+        type: string
+      title:
+        _description: |-
+          A one-line title or summary of the issue. This exists mostly
+          for human consumption, as "Implement widget X" is much more meaningful to a
+          human when viewing a graph of Eiffel events than "1302". This is not meant
+          to be a detailed description, as such information should be accessible by
+          following __data.uri__.
+        type: string
+      customData:
+        type: array
+        items:
+          $ref: ../EiffelCustomDataProperty/2.0.0.yml
+    required:
+      - type
+      - tracker
+      - id
+      - uri
+    additionalProperties: false
+  links:
+    type: array
+    items:
+      $ref: ../EiffelEventLink/2.0.0.yml
+_links:
+  CAUSE:
+    description: 'Identifies a cause of the event occurring. SHOULD
+      not be used in conjunction with __CONTEXT__: individual events
+      providing __CAUSE__ within a larger context gives rise to ambiguity.
+      It is instead recommended to let the root event of the context
+      declare __CAUSE__.'
+    required: false
+    multiple: true
+    targets:
+      any_type: true
+      types: []
+  CONTEXT:
+    description: Identifies the activity or test suite of which this
+      event constitutes a part.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelActivityTriggeredEvent
+        - EiffelTestSuiteStartedEvent
+  FLOW_CONTEXT:
+    description: 'Identifies the flow context of the event: which is
+      the continuous integration and delivery flow in which this occurred
+      – e.g. which product, project, track or version this is applicable
+      to.'
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelFlowContextDefinedEvent
+_history:
+  - version: 4.0.0
+    changes: Update meta schema to Draft 2020-12.
+  - version: 3.2.0
+    introduced_in: edition-arica
+    changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
+  - version: 3.1.0
+    introduced_in: edition-lyon
+    changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
+  - version: 3.0.0
+    introduced_in: edition-agen
+    changes: Improved information integrity protection (see [Issue
+      185](https://github.com/eiffel-community/eiffel/issues/185)).
+  - version: 2.0.0
+    introduced_in: edition-agen
+    changes: Introduced purl identifiers instead of GAVs (see [Issue
+      182](https://github.com/eiffel-community/eiffel/issues/182))
+  - version: 1.0.0
+    introduced_in: edition-agen
+    changes: Initial version
+_examples:
+  - title: Simple example
+    url: ../examples/events/EiffelIssueDefinedEvent/simple.json

--- a/definitions/EiffelIssueVerifiedEvent/5.0.0.yml
+++ b/definitions/EiffelIssueVerifiedEvent/5.0.0.yml
@@ -1,0 +1,172 @@
+# Copyright 2017-2024 Ericsson AB and others.
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+$schema: https://json-schema.org/draft/draft-2020-12/schema#
+_name: EiffelIssueVerifiedEvent
+_version: 5.0.0
+_abbrev: IV
+_description: |-
+  The EiffelIssueVerifiedEvent declares that an issue, typically a requirement, has been verified by some means. It is different from [EiffelTestCaseFinishedEvent](./EiffelTestCaseFinishedEvent.md) in that multiple test case executions may serve as the basis for a single verification or, conversely, multiple issues may be verified based on a single test case execution.
+
+  EiffelIssueVerifiedEvent has no data members, instead relying on its required link types. While "SUCCESSFUL_ISSUE", "FAILED_ISSUE", and "INCONCLUSIVE_ISSUE" are all marked as not required, at least one link of at least one of these types MUST be present in an EiffelIssueVerifiedEvent.
+type: object
+properties:
+  meta:
+    $ref: ../EiffelMetaProperty/4.0.0.yml
+  data:
+    type: object
+    properties:
+      customData:
+        type: array
+        items:
+          $ref: ../EiffelCustomDataProperty/2.0.0.yml
+    additionalProperties: false
+  links:
+    type: array
+    contains:
+      type: object
+      properties:
+        type:
+          enum:
+            - IUT
+    items:
+      $ref: ../EiffelEventLink/2.0.0.yml
+required:
+  - meta
+  - data
+  - links
+additionalProperties: false
+_links:
+  CAUSE:
+    description: 'Identifies a cause of the event occurring. SHOULD
+      not be used in conjunction with __CONTEXT__: individual events
+      providing __CAUSE__ within a larger context gives rise to ambiguity.
+      It is instead recommended to let the root event of the context
+      declare __CAUSE__.'
+    required: false
+    multiple: true
+    targets:
+      any_type: true
+      types: []
+  CONTEXT:
+    description: Identifies the activity or test suite of which this
+      event constitutes a part.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelActivityTriggeredEvent
+        - EiffelTestSuiteStartedEvent
+  ENVIRONMENT:
+    description: Identifies the environment in which the issue was
+      verified.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelEnvironmentDefinedEvent
+  FAILED_ISSUE:
+    description: Identifies an issue that has failed verification.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelIssueDefinedEvent
+  FLOW_CONTEXT:
+    description: 'Identifies the flow context of the event: which is
+      the continuous integration and delivery flow in which this occurred
+      – e.g. which product, project, track or version this is applicable
+      to.'
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelFlowContextDefinedEvent
+  INCONCLUSIVE_ISSUE:
+    description: Identifies an issue for which this verification was
+      inconclusive.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelIssueDefinedEvent
+  IUT:
+    description: Identifies the Implementation Under Test; in other words, the
+      entity for which the issue has been verified.
+    required: true
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelArtifactCreatedEvent
+        - EiffelArtifactDeployedEvent
+        - EiffelCompositionDefinedEvent
+  SUCCESSFUL_ISSUE:
+    description: Identifies an issue that has been successfully verified.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelIssueDefinedEvent
+  VERIFICATION_BASIS:
+    description: Used to declare the basis on which the verification
+      statement(s) of this event have been issued.
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelTestCaseFinishedEvent
+        - EiffelTestSuiteFinishedEvent
+_history:
+  - version: 5.0.0
+    changes: Update meta schema to Draft 2020-12.
+  - version: 4.3.1
+    changes: Change IUT to Implementation Under Test (see [Issue 235](https://github.com/eiffel-community/eiffel/issues/359)).
+  - version: 4.3.0
+    introduced_in: edition-orizaba
+    changes: Add artifact deployed event as legal IUT target (see [Issue 239](https://github.com/eiffel-community/eiffel/issues/239)).
+  - version: 4.2.0
+    introduced_in: edition-arica
+    changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
+  - version: 4.1.0
+    introduced_in: edition-lyon
+    changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
+  - version: 4.0.0
+    introduced_in: edition-agen
+    changes: Improved information integrity protection (see [Issue
+      185](https://github.com/eiffel-community/eiffel/issues/185)).
+  - version: 3.0.0
+    introduced_in: edition-agen
+    changes: Introduced purl identifiers instead of GAVs (see [Issue
+      182](https://github.com/eiffel-community/eiffel/issues/182))
+  - version: 2.0.0
+    introduced_in: edition-agen
+    changes: Replaced data.issues with links
+  - version: 1.1.0
+    introduced_in: edition-toulouse
+    changes: Multiple links of type FLOW_CONTEXT allowed.
+  - version: 1.0.0
+    introduced_in: edition-bordeaux
+    changes: Initial version.
+_examples:
+  - title: Simple example
+    url: ../examples/events/EiffelIssueVerifiedEvent/simple.json

--- a/definitions/EiffelIssueVerifiedEvent/5.0.0.yml
+++ b/definitions/EiffelIssueVerifiedEvent/5.0.0.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-$schema: https://json-schema.org/draft/draft-2020-12/schema#
+$schema: https://json-schema.org/draft/2020-12/schema#
 _name: EiffelIssueVerifiedEvent
 _version: 5.0.0
 _abbrev: IV
@@ -138,7 +138,7 @@ _links:
         - EiffelTestSuiteFinishedEvent
 _history:
   - version: 5.0.0
-    changes: Update meta schema to Draft 2020-12.
+    changes: Update meta schema to Draft 2020-12 and add link validation.
   - version: 4.3.1
     changes: Change IUT to Implementation Under Test (see [Issue 235](https://github.com/eiffel-community/eiffel/issues/359)).
   - version: 4.3.0

--- a/definitions/EiffelMetaProperty/4.0.0.yml
+++ b/definitions/EiffelMetaProperty/4.0.0.yml
@@ -1,0 +1,212 @@
+# Copyright 2017-2024 Ericsson AB and others.
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+$schema: https://json-schema.org/draft/draft-2020-12/schema#
+_name: EiffelMetaProperty
+_version: 4.0.0
+type: object
+properties:
+  id:
+    _description: >-
+      The unique identity of the event, generated at event creation.
+    _format: '[UUID](http://tools.ietf.org/html/rfc4122)'
+    type: string
+    pattern: ^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$
+  type:
+    _description: >-
+      The type of event. This field is required by the recipient of
+      the event, as each event type has a specific meaning and a specific
+      set of members in the __data__ and __links__ objects.
+    _format: An event type name
+    type: string
+  version:
+    _description: >-
+      The version of the event type. This field is required by the recipient
+      of the event to interpret the contents. Please see
+      [Versioning](../eiffel-syntax-and-usage/versioning.md) for more
+      information.
+    _format: '[Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html)'
+    type: string
+  time:
+    _description: The event creation timestamp.
+    _format: UNIX Epoch time, in milliseconds.
+    type: integer
+  tags:
+    _description: >-
+      Any tags or keywords associated with the events, for searchability
+      purposes.
+    _format: Free text
+    type: array
+    items:
+      type: string
+  source:
+    _description: >-
+      A description of the source of the event. This object is primarily for
+      traceability purposes, and while optional, some form of identification
+      of the source is __HIGHLY RECOMMENDED__. It offers multiple methods of
+      identifying the source of the event, techniques which may be select from
+      based on the technology domain and needs in any particular use case.
+    type: object
+    properties:
+      domainId:
+        _description: >-
+          Identifies the
+          [domain](../eiffel-syntax-and-usage/glossary.md#domain) that
+          produced an event.
+        _format: Free text
+        type: string
+      host:
+        _description: The hostname of the event sender.
+        _format: Hostname
+        type: string
+      name:
+        _description: The name of the event sender.
+        _format: Free text
+        type: string
+      serializer:
+        _description: >-
+          The identity of the serializer software used to construct the event,
+          in [purl format](https://github.com/package-url/purl-spec).
+        _format: >-
+          [purl specification](https://github.com/package-url/purl-spec)
+        type: string
+        pattern: '^pkg:'
+      uri:
+        _description: The URI of, related to or describing the event sender.
+        _format: URI
+        type: string
+    additionalProperties: false
+  security:
+    _description: >-
+      An optional object for enclosing security related information,
+      particularly supporting data integrity. See
+      [Security](../eiffel-syntax-and-usage/security.md) for further
+      information.
+    type: object
+    properties:
+      authorIdentity:
+        _description: >-
+          The identity of the author of the event. This property is intended
+          to enable the recipient to identify the author of the event contents
+          and/or look up the appropriate public key for decrypting the
+          __meta.security.integrityProtection.signature__ value and thereby
+          verifying author identity and data integrity.
+        _format: '[Distinguished Name](https://tools.ietf.org/html/rfc2253)'
+        type: string
+      integrityProtection:
+        _description: >-
+          An optional object for enabling information integrity protection via
+          cryptographic signing. To generate a correct
+          __meta.security.integrityProtection__ object:
+          
+            1. Generate the entire event, but with the
+               __meta.security.integrityProtection.signature__ value set to
+               an empty string.
+            1. Serialize the event on
+               [Canonical JSON Form](https://tools.ietf.org/html/draft-staykov-hu-json-canonical-form-00).
+            1. Generate the signature using the
+               __meta.security.integrityProtection.alg__ algorithm.
+            1. Set the __meta.security.integrityProtection.signature__ value to
+               the resulting signature while maintaining Canonical JSON Form.
+          To verify the integrity of the event, the consumer then resets
+          __meta.security.integrityProtection.signature__ to an empty string
+          and ensures Canonical JSON Form before verifying the signature.
+        type: object
+        properties:
+          signature:
+            _description: The signature produced by the signing algorithm.
+            type: string
+          alg:
+            _description: >-
+              The cryptographic algorithm used to digitally sign the event.
+              If no signing is performed, the
+              __meta.security.integrityProtection__ SHALL be omitted rather
+              than setting __meta.security.integrityProtection.alg__ to "none".
+            _format: >-
+              [A valid JWA RFC 7518 alg parameter value](https://tools.ietf.org/html/rfc7518#section-3.1),
+              excluding "none"
+            type: string
+            enum:
+              - HS256
+              - HS384
+              - HS512
+              - RS256
+              - RS384
+              - RS512
+              - ES256
+              - ES384
+              - ES512
+              - PS256
+              - PS384
+              - PS512
+          publicKey:
+            _description: >-
+              The producer of the event may include the relevant public key
+              for convenience, rather than relying a separate key distribution
+              mechanism. Note that this property, along with the rest of the
+              event, is encompassed by the integrity protection offered via
+              __meta.security.integrityProtection__.
+            type: string
+        required:
+          - signature
+          - alg
+        additionalProperties: false
+      sequenceProtection:
+        _description: >-
+          An optional object for enabling verification of intact event
+          sequences in a distributed environment, thereby protecting against
+          data loss, race conditions and replay attacks. It allows event
+          publishers to state the order in which they produce a certain set
+          of events. In other words, it cannot provide any global guarantees
+          as to event sequencing, but rather per-publisher guarantees. Every
+          object in the array represents a named sequence of which this event
+          forms a part. For every event including a given named sequence,
+          the publisher SHALL increment
+          __meta.security.sequenceProtection.position__ by 1. The first event
+          produced in a given named sequence SHALL numbered 1.
+        type: array
+        items:
+          type: object
+          properties:
+            sequenceName:
+              _description: >-
+                The name of the sequence. There MUST not be two identical
+                __meta.security.sequenceProtection.sequenceName__ values in
+                the same event.
+              type: string
+            position:
+              _description: The number of the event within the named sequence.
+              type: integer
+          additionalProperties: false
+          required:
+            - sequenceName
+            - position
+    additionalProperties: false
+    required:
+      - authorIdentity
+  schemaUri:
+    _description: >-
+      A URI pointing at a location from where the schema used when creating this
+      event can be retrieved. It can be used to parse event data for validation
+      and extraction purposes, for example. Note, that the schema on that URI
+      should be considered immutable.
+    _format: URI
+    type: string
+required:
+  - id
+  - type
+  - version
+  - time
+additionalProperties: false

--- a/definitions/EiffelSourceChangeCreatedEvent/5.0.0.yml
+++ b/definitions/EiffelSourceChangeCreatedEvent/5.0.0.yml
@@ -1,0 +1,301 @@
+# Copyright 2017-2024 Ericsson AB and others.
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+$schema: https://json-schema.org/draft/draft-2020-12/schema#
+_name: EiffelSourceChangeCreatedEvent
+_version: 5.0.0
+_abbrev: SCC
+_description: |-
+  The EiffelSourceChangeCreatedEvent declares that a change to sources has been made, but not yet submitted (see [EiffelSourceChangeSubmittedEvent](./EiffelSourceChangeSubmittedEvent.md)). This can be used to represent a change done on a private branch, undergoing review or made in a forked repository. Unlike EiffelSourceChangeSubmittedEvent, EiffelSourceChangeCreatedEvent _describes the change_ in terms of who authored it and which issues it addressed.
+
+  Where changes are integrated (or "submitted") directly on a shared branch of interest (e.g. "master", "dev" or "mainline") both EiffelSourceChangeCreatedEvent and EiffelSourceChangeSubmittedEvent are sent together.
+type: object
+properties:
+  meta:
+    $ref: ../EiffelMetaProperty/4.0.0.yml
+  data:
+    type: object
+    properties:
+      author:
+        _description: The author of the change.
+        type: object
+        properties:
+          name:
+            _description: The name of the author.
+            type: string
+          email:
+            _description: The email address of the author.
+            type: string
+          id:
+            _description: Any identity, username or alias of the author.
+            type: string
+          group:
+            _description: Any group or organization to which the contributor
+              belongs.
+            type: string
+        additionalProperties: false
+      change:
+        _description: A summary of the change.
+        type: object
+        properties:
+          insertions:
+            _description: The number of inserted lines in the change.
+            type: integer
+          deletions:
+            _description: The number of deleted lines in the change.
+            type: integer
+          files:
+            _description: A URI to a list of files changed, on JSON
+              String array format.
+            type: string
+          details:
+            _description: A URI to further details about the change.
+              These details are not assumed to be on any standardized
+              format, and may be intended for human and/or machine
+              consumption. Examples include e.g. Gerrit patch set descriptions
+              or GitHub commit pages. It is recommended to also include
+              __data.change.tracker__ to provide a hint as to the nature
+              of the linked details.
+            type: string
+          tracker:
+            _description: The name of the tracker, if any, of the change.
+              Examples include e.g. Gerrit or GitHub.
+            type: string
+          id:
+            _description: The unique identity, if any, of the change
+              (apart from what is expressed in the identifier object).
+              Examples include e.g. Gerrit Change-Ids or GitHub Pull
+              Requests. It is recommended to also include __data.change.tracker__
+              to provide a hint as to the nature of the identity.
+            type: string
+        additionalProperties: false
+      gitIdentifier:
+        _description: Identifier of a Git change.
+        type: object
+        properties:
+          commitId:
+            _description: The commit identity (hash) of the change.
+            type: string
+          branch:
+            _description: The name of the branch where the change was
+              made.
+            type: string
+          repoName:
+            _description: The name of the repository containing the
+              change.
+            type: string
+          repoUri:
+            _description: The URI of the repository containing the
+              change.
+            type: string
+        required:
+          - commitId
+          - repoUri
+        additionalProperties: false
+      svnIdentifier:
+        _description: Identifier of a Subversion change.
+        type: object
+        properties:
+          revision:
+            _description: The revision of the change.
+            type: integer
+          directory:
+            _description: The directory (branch/tag) of the change.
+            type: string
+          repoName:
+            _description: The name of the repository containing the
+              change.
+            type: string
+          repoUri:
+            _description: The URI of the repository containing the
+              change.
+            type: string
+        required:
+          - revision
+          - directory
+          - repoUri
+        additionalProperties: false
+      ccCompositeIdentifier:
+        _description: Identifier of a composite ClearCase change –
+          in other words, not single file commit, but analogous of
+          repository-wide commits of e.g. SVN or Git.
+        type: object
+        properties:
+          vobs:
+            _description: The names of the changed ClearCase VOBs.
+            type: array
+            items:
+              type: string
+          branch:
+            _description: The branch of the change.
+            type: string
+          configSpec:
+            _description: The URI of the relevant ClearCase config
+              spec.
+            type: string
+        required:
+          - vobs
+          - branch
+          - configSpec
+        additionalProperties: false
+      hgIdentifier:
+        _description: Identifier of a Mercurial change.
+        type: object
+        properties:
+          commitId:
+            _description: The commit identity (hash) of the change.
+            type: string
+          branch:
+            _description: The branch of the change.
+            type: string
+          repoName:
+            _description: The name of the repo.
+            type: string
+          repoUri:
+            _description: The URI of the repo.
+            type: string
+        required:
+          - commitId
+          - repoUri
+        additionalProperties: false
+      customData:
+        type: array
+        items:
+          $ref: ../EiffelCustomDataProperty/2.0.0.yml
+    additionalProperties: false
+  links:
+    type: array
+    items:
+      $ref: ../EiffelEventLink/2.0.0.yml
+required:
+  - meta
+  - data
+  - links
+additionalProperties: false
+_links:
+  BASE:
+    description: Identifies the base revision of the created source
+      change.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelSourceChangeSubmittedEvent
+  CAUSE:
+    description: 'Identifies a cause of the event occurring. SHOULD
+      not be used in conjunction with __CONTEXT__: individual events
+      providing __CAUSE__ within a larger context gives rise to ambiguity.
+      It is instead recommended to let the root event of the context
+      declare __CAUSE__.'
+    required: false
+    multiple: true
+    targets:
+      any_type: true
+      types: []
+  CONTEXT:
+    description: Identifies the activity or test suite of which this
+      event constitutes a part.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelActivityTriggeredEvent
+        - EiffelTestSuiteStartedEvent
+  DERESOLVED_ISSUE:
+    description: Identifies an issue which was previously resolved,
+      but that this SCC claims it has made changes to warrant removing
+      the resolved status. For example, if an issue "Feature X" was
+      resolved, but this SCC removed the implementation that led to
+      "Feature X" being resolved, that issue should no longer be considered
+      resolved.
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelIssueDefinedEvent
+  FLOW_CONTEXT:
+    description: 'Identifies the flow context of the event: which is
+      the continuous integration and delivery flow in which this occurred
+      – e.g. which product, project, track or version this is applicable
+      to.'
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelFlowContextDefinedEvent
+  PARTIALLY_RESOLVED_ISSUE:
+    description: Identifies an issue that this event partially resolves.
+      That is, this SCC introduces some change that has advanced an
+      issue towards a resolved state, but not completely resolved.
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelIssueDefinedEvent
+  PREVIOUS_VERSION:
+    description: Identifies a latest previous version (there may be
+      more than one in case of merges) of the created source change.
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelSourceChangeCreatedEvent
+  RESOLVED_ISSUE:
+    description: Identifies an issue that this SCC is claiming it has
+      done enough to resolve. This is not an authoritative resolution,
+      only a claim. The issue may or may not change status as a consequence
+      this, e.g. through a [successful verification](../eiffel-vocabular/EiffelIssueVerifiedEvent.md)
+      or a manual update on the issue tracker.
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelIssueDefinedEvent
+_history:
+  - version: 5.0.0
+    changes: Update meta schema to Draft 2020-12.
+  - version: 4.2.0
+    introduced_in: edition-arica
+    changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
+  - version: 4.1.0
+    introduced_in: edition-lyon
+    changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
+  - version: 4.0.0
+    introduced_in: edition-agen
+    changes: Improved information integrity protection (see [Issue
+      185](https://github.com/eiffel-community/eiffel/issues/185)).
+  - version: 3.0.0
+    introduced_in: edition-agen
+    changes: Introduced purl identifiers instead of GAVs (see [Issue
+      182](https://github.com/eiffel-community/eiffel/issues/182))
+  - version: 2.0.0
+    introduced_in: edition-agen
+    changes: Replaced data.issues with links
+  - version: 1.1.0
+    introduced_in: edition-toulouse
+    changes: Multiple links of type FLOW_CONTEXT allowed.
+  - version: 1.0.0
+    introduced_in: edition-bordeaux
+    changes: Initial version.
+_examples:
+  - title: Simple example
+    url: ../examples/events/EiffelSourceChangeCreatedEvent/simple.json

--- a/definitions/EiffelSourceChangeCreatedEvent/5.0.0.yml
+++ b/definitions/EiffelSourceChangeCreatedEvent/5.0.0.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-$schema: https://json-schema.org/draft/draft-2020-12/schema#
+$schema: https://json-schema.org/draft/2020-12/schema#
 _name: EiffelSourceChangeCreatedEvent
 _version: 5.0.0
 _abbrev: SCC
@@ -272,7 +272,7 @@ _links:
         - EiffelIssueDefinedEvent
 _history:
   - version: 5.0.0
-    changes: Update meta schema to Draft 2020-12.
+    changes: Update meta schema to Draft 2020-12 and add link validation.
   - version: 4.2.0
     introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).

--- a/definitions/EiffelSourceChangeSubmittedEvent/4.0.0.yml
+++ b/definitions/EiffelSourceChangeSubmittedEvent/4.0.0.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-$schema: https://json-schema.org/draft/draft-2020-12/schema#
+$schema: https://json-schema.org/draft/2020-12/schema#
 _name: EiffelSourceChangeSubmittedEvent
 _version: 4.0.0
 _abbrev: SCS
@@ -205,7 +205,7 @@ _links:
         - EiffelSourceChangeSubmittedEvent
 _history:
   - version: 4.0.0
-    changes: Update meta schema to Draft 2020-12.
+    changes: Update meta schema to Draft 2020-12 and add link validation.
   - version: 3.2.0
     introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).

--- a/definitions/EiffelSourceChangeSubmittedEvent/4.0.0.yml
+++ b/definitions/EiffelSourceChangeSubmittedEvent/4.0.0.yml
@@ -1,0 +1,231 @@
+# Copyright 2017-2024 Ericsson AB and others.
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+$schema: https://json-schema.org/draft/draft-2020-12/schema#
+_name: EiffelSourceChangeSubmittedEvent
+_version: 4.0.0
+_abbrev: SCS
+_description: |-
+  The EiffelSourceChangeSubmittedEvent declares that a change has been integrated into to a shared source branch of interest (e.g. "master", "dev" or "mainline") as opposed to a private or local branch. Note that it does not describe what has changed, but instead uses the __CHANGE__ link type to reference [EiffelSourceChangeCreatedEvent](./EiffelSourceChangeCreatedEvent.md).
+
+  Typical use cases for EiffelSourceChangeSubmittedEvent is to signal that a patch has passed code review and been submitted or that a feature/topic/team branch has been merged into the mainline/trunk/master. Where changes are made directly on the mainline, it is recommended to send both [EiffelSourceChangeCreatedEvent](./EiffelSourceChangeCreatedEvent.md) and EiffelSourceChangeSubmittedEvent together for information completeness.
+
+  Even though multiple types of identifiers are available (see below), the event SHOULD include one and SHALL not include more than one; changes to multiple repositories are represented by multiple events.
+type: object
+properties:
+  meta:
+    $ref: ../EiffelMetaProperty/4.0.0.yml
+  data:
+    type: object
+    properties:
+      submitter:
+        _description: The agent (individual, group or machine) submitting
+          the change. This is crucially different from the __data.author__
+          field of [EiffelSourceChangeCreatedEvent](./EiffelSourceChangeCreatedEvent.md).
+        type: object
+        properties:
+          name:
+            _description: The name of the submitter.
+            type: string
+          email:
+            _description: The email address of the submitter.
+            type: string
+          id:
+            _description: Any identity, username or alias of the submitter.
+            type: string
+          group:
+            _description: Any group or organization to which the submitter
+              belongs.
+            type: string
+        additionalProperties: false
+      gitIdentifier:
+        _description: Identifier of a Git change.
+        type: object
+        properties:
+          commitId:
+            _description: The commit identity (hash) of the change.
+            type: string
+          branch:
+            _description: The name of the branch where the change was
+              made.
+            type: string
+          repoName:
+            _description: The name of the repository containing the
+              change.
+            type: string
+          repoUri:
+            _description: The URI of the repository containing the
+              change.
+            type: string
+        required:
+          - commitId
+          - repoUri
+        additionalProperties: false
+      svnIdentifier:
+        _description: Identifier of a Subversion change.
+        type: object
+        properties:
+          revision:
+            _description: The revision of the change.
+            type: integer
+          directory:
+            _description: The directory (branch/tag) of the change.
+            type: string
+          repoName:
+            _description: The name of the repository containing the
+              change.
+            type: string
+          repoUri:
+            _description: The URI of the repository containing the
+              change.
+            type: string
+        required:
+          - revision
+          - directory
+          - repoUri
+        additionalProperties: false
+      ccCompositeIdentifier:
+        _description: Identifier of a composite ClearCase change –
+          in other words, not single file commit, but analogous of
+          repository-wide commits of e.g. SVN or Git.
+        type: object
+        properties:
+          vobs:
+            _description: The names of the changed ClearCase VOBs.
+            type: array
+            items:
+              type: string
+          branch:
+            _description: The branch of the change.
+            type: string
+          configSpec:
+            _description: The URI of the relevant ClearCase config
+              spec.
+            type: string
+        required:
+          - vobs
+          - branch
+          - configSpec
+        additionalProperties: false
+      hgIdentifier:
+        _description: Identifier of a Mercurial change.
+        type: object
+        properties:
+          commitId:
+            _description: The commit identity (hash) of the change.
+            type: string
+          branch:
+            _description: The branch of the change.
+            type: string
+          repoName:
+            _description: The name of the repo.
+            type: string
+          repoUri:
+            _description: The URI of the repo.
+            type: string
+        required:
+          - commitId
+          - repoUri
+        additionalProperties: false
+      customData:
+        type: array
+        items:
+          $ref: ../EiffelCustomDataProperty/2.0.0.yml
+    additionalProperties: false
+  links:
+    type: array
+    items:
+      $ref: ../EiffelEventLink/2.0.0.yml
+required:
+  - meta
+  - data
+  - links
+additionalProperties: false
+_links:
+  CAUSE:
+    description: 'Identifies a cause of the event occurring. SHOULD
+      not be used in conjunction with __CONTEXT__: individual events
+      providing __CAUSE__ within a larger context gives rise to ambiguity.
+      It is instead recommended to let the root event of the context
+      declare __CAUSE__.'
+    required: false
+    multiple: true
+    targets:
+      any_type: true
+      types: []
+  CHANGE:
+    description: Identifies the change that was submitted.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelSourceChangeCreatedEvent
+  CONTEXT:
+    description: Identifies the activity or test suite of which this
+      event constitutes a part.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelActivityTriggeredEvent
+        - EiffelTestSuiteStartedEvent
+  FLOW_CONTEXT:
+    description: 'Identifies the flow context of the event: which is
+      the continuous integration and delivery flow in which this occurred
+      – e.g. which product, project, track or version this is applicable
+      to.'
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelFlowContextDefinedEvent
+  PREVIOUS_VERSION:
+    description: Identifies a latest previous version (there may be
+      more than one in case of merges) of the submitted source change.
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelSourceChangeSubmittedEvent
+_history:
+  - version: 4.0.0
+    changes: Update meta schema to Draft 2020-12.
+  - version: 3.2.0
+    introduced_in: edition-arica
+    changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
+  - version: 3.1.0
+    introduced_in: edition-lyon
+    changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
+  - version: 3.0.0
+    introduced_in: edition-agen
+    changes: Improved information integrity protection (see [Issue
+      185](https://github.com/eiffel-community/eiffel/issues/185)).
+  - version: 2.0.0
+    introduced_in: edition-agen
+    changes: Introduced purl identifiers instead of GAVs (see [Issue
+      182](https://github.com/eiffel-community/eiffel/issues/182))
+  - version: 1.1.0
+    introduced_in: edition-toulouse
+    changes: Multiple links of type FLOW_CONTEXT allowed.
+  - version: 1.0.0
+    introduced_in: edition-bordeaux
+    changes: Initial version.
+_examples:
+  - title: Simple example
+    url: ../examples/events/EiffelSourceChangeSubmittedEvent/simple.json

--- a/definitions/EiffelTestCaseCanceledEvent/4.0.0.yml
+++ b/definitions/EiffelTestCaseCanceledEvent/4.0.0.yml
@@ -1,0 +1,129 @@
+# Copyright 2017-2024 Ericsson AB and others.
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+$schema: https://json-schema.org/draft/draft-2020-12/schema#
+_name: EiffelTestCaseCanceledEvent
+_version: 4.0.0
+_abbrev: TCC
+_description: The EiffelTestCaseCanceledEvent declares that a previously
+  triggered test case execution (represented by [EiffelTestCaseTriggeredEvent](./EiffelTestCaseTriggeredEvent.md))
+  has been canceled _before it has started_. This is typically used
+  in queuing situations where a queued execution is dequeued. It is
+  recommended that __CAUSE__ links be used to indicate the reason.
+type: object
+properties:
+  meta:
+    $ref: ../EiffelMetaProperty/4.0.0.yml
+  data:
+    type: object
+    properties:
+      reason:
+        _description: Any human readable information as to the reason
+          for dequeueing.
+        type: string
+      customData:
+        type: array
+        items:
+          $ref: ../EiffelCustomDataProperty/2.0.0.yml
+    additionalProperties: false
+  links:
+    type: array
+    contains:
+      type: object
+      properties:
+        type:
+          enum:
+            - TEST_CASE_EXECUTION
+    items:
+      $ref: ../EiffelEventLink/2.0.0.yml
+required:
+  - meta
+  - data
+  - links
+additionalProperties: false
+_links:
+  CAUSE:
+    description: While for most events it is recommended that __CAUSE__
+      SHOULD not be used in conjunction with __CONTEXT__, EiffelTestCaseCanceledEvent
+      is a special case as it represents a deviation from previous
+      intention. Therefore it is recommended that __CAUSE__ always
+      be included where applicable.
+    required: false
+    multiple: true
+    targets:
+      any_type: true
+      types: []
+  CONTEXT:
+    description: Identifies the activity or test suite of which this
+      event constitutes a part.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelActivityTriggeredEvent
+        - EiffelTestSuiteStartedEvent
+  FLOW_CONTEXT:
+    description: 'Identifies the flow context of the event: which is
+      the continuous integration and delivery flow in which this occurred
+      – e.g. which product, project, track or version this is applicable
+      to.'
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelFlowContextDefinedEvent
+  TEST_CASE_EXECUTION:
+    description: Identifies the relevant test case execution. In other
+      words, [EiffelTestCaseTriggeredEvent](../eiffel-vocabulary/EiffelTestCaseTriggeredEvent.md)
+      acts as a handle for a particular test case execution. This differs
+      from __CONTEXT__. In __TEST_CASE_EXECUTION__ the source carries
+      information pertaining to the target (i.e. the test case execution
+      started, finished or was canceled). In __CONTEXT__, on the other
+      hand, the source constitutes a subset of the target (e.g. this
+      test case was executed as part of that activity or test suite).
+    required: true
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelTestCaseTriggeredEvent
+_history:
+  - version: 4.0.0
+    changes: Update meta schema to Draft 2020-12.
+  - version: 3.2.0
+    introduced_in: edition-arica
+    changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
+  - version: 3.1.0
+    introduced_in: edition-lyon
+    changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
+  - version: 3.0.0
+    introduced_in: edition-agen
+    changes: Improved information integrity protection (see [Issue
+      185](https://github.com/eiffel-community/eiffel/issues/185)).
+  - version: 2.0.0
+    introduced_in: edition-agen
+    changes: Introduced purl identifiers instead of GAVs (see [Issue
+      182](https://github.com/eiffel-community/eiffel/issues/182))
+  - version: 1.1.0
+    introduced_in: edition-toulouse
+    changes: Multiple links of type FLOW_CONTEXT allowed.
+  - version: 1.0.0
+    introduced_in: edition-bordeaux
+    changes: Initial version.
+_examples:
+  - title: Simple example
+    url: ../examples/events/EiffelTestCaseCanceledEvent/simple.json

--- a/definitions/EiffelTestCaseCanceledEvent/4.0.0.yml
+++ b/definitions/EiffelTestCaseCanceledEvent/4.0.0.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-$schema: https://json-schema.org/draft/draft-2020-12/schema#
+$schema: https://json-schema.org/draft/2020-12/schema#
 _name: EiffelTestCaseCanceledEvent
 _version: 4.0.0
 _abbrev: TCC
@@ -103,7 +103,7 @@ _links:
         - EiffelTestCaseTriggeredEvent
 _history:
   - version: 4.0.0
-    changes: Update meta schema to Draft 2020-12.
+    changes: Update meta schema to Draft 2020-12 and add link validation.
   - version: 3.2.0
     introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).

--- a/definitions/EiffelTestCaseFinishedEvent/4.0.0.yml
+++ b/definitions/EiffelTestCaseFinishedEvent/4.0.0.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-$schema: https://json-schema.org/draft/draft-2020-12/schema#
+$schema: https://json-schema.org/draft/2020-12/schema#
 _name: EiffelTestCaseFinishedEvent
 _version: 4.0.0
 _abbrev: TCF
@@ -191,7 +191,7 @@ _links:
         - EiffelTestCaseTriggeredEvent
 _history:
   - version: 4.0.0
-    changes: Update meta schema to Draft 2020-12.
+    changes: Update meta schema to Draft 2020-12 and add link validation.
   - version: 3.3.1
     changes: Change IUT to Implementation Under Test (see [Issue 235](https://github.com/eiffel-community/eiffel/issues/359)).
   - version: 3.3.0

--- a/definitions/EiffelTestCaseFinishedEvent/4.0.0.yml
+++ b/definitions/EiffelTestCaseFinishedEvent/4.0.0.yml
@@ -1,0 +1,226 @@
+# Copyright 2017-2024 Ericsson AB and others.
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+$schema: https://json-schema.org/draft/draft-2020-12/schema#
+_name: EiffelTestCaseFinishedEvent
+_version: 4.0.0
+_abbrev: TCF
+_description: |-
+  The EiffelTestCaseFinishedEvent declares that a previously started test case (declared by [EiffelTestCaseStartedEvent](./EiffelTestCaseStartedEvent.md)) has finished and reports the outcome.
+
+  Note that while similar, the __data.outcome__ object is different from that of [EiffelActivityFinishedEvent](./EiffelActivityFinishedEvent.md). The outcome of the test case reports not only the conclusion of the test case execution - whether the test case was successfully executed - but also passes a verdict on the implementation under test. To highlight this conceptual difference, both __data.outcome.verdict__ and __data.outcome.conclusion__ are included.
+
+  Also note that unlike [EiffelTestSuiteFinishedEvent](./EiffelTestSuiteFinishedEvent.md), EiffelTestCaseFinishedEvent must report both __data.outcome.verdict__ and __data.outcome.conclusion__.
+type: object
+properties:
+  meta:
+    $ref: ../EiffelMetaProperty/4.0.0.yml
+  data:
+    type: object
+    properties:
+      outcome:
+        _description: The outcome of the test case.
+        type: object
+        properties:
+          verdict:
+            _description: |-
+              A terse standardized verdict on the item or items under test.
+              PASSED signifies that the item or items under test successfully passed the test case.  
+              FAILED signifies that the item or items under test failed to pass the test case.  
+              INCONCLUSIVE signifies that the verdict of the test case was inconclusive. This SHOULD be the case if __data.outcome.conclusion__ is not __SUCCESSFUL__, but may in combination with a __SUCCESSFUL__ conclusion be used to represent unreliability or flakiness.
+            type: string
+            enum:
+              - PASSED
+              - FAILED
+              - INCONCLUSIVE
+          conclusion:
+            _description: |-
+              A terse standardized conclusion of the test case, designed to be machine readable.
+              SUCCESSFUL signifies that the test case was successfully concluded. Note that this does not imply that the implementation under test passed the tests.  
+              FAILED signifies that the test case could not be successfully executed. To exemplify, one or more tests failed to run due to required environments being unavailable.  
+              ABORTED signifies that the test case was aborted before it could be concluded.  
+              TIMED_OUT signifies that the test case did not conclude within the allowed time frame.  
+              INCONCLUSIVE signifies that the outcome of the test case could not be determined.
+            type: string
+            enum:
+              - SUCCESSFUL
+              - FAILED
+              - ABORTED
+              - TIMED_OUT
+              - INCONCLUSIVE
+          description:
+            _description: A verbose description of the test case outcome,
+              designed to provide human readers with further information.
+            type: string
+          metrics:
+            _description: A list of metrics collected during the test
+              case execution. Note that while complete freedom is allowed
+              in metrics names and value types, it is highly recommended
+              to keep reported metrics concise and consistent. In other
+              words, do not include excessive amounts of data (use
+              __data.persistentLogs__ for that), and avoid unnecessary
+              variations in value names or types over time.
+            type: array
+            items:
+              type: object
+              properties:
+                name:
+                  _description: The metrics name.
+                  type: string
+                value:
+                  _description: The metrics value.
+              required:
+                - name
+                - value
+              additionalProperties: false
+        required:
+          - verdict
+          - conclusion
+        additionalProperties: false
+      persistentLogs:
+        _description: An array of persistent log files generated during
+          execution.
+        type: array
+        items:
+          type: object
+          properties:
+            mediaType:
+              _description: The [media type](https://en.wikipedia.org/wiki/Media_type)
+                of the URI's payload. Can be used to differentiate
+                between various representations of the same log, e.g.
+                text/html for human consumption and text/plain or application/json
+                for the machine-readable form.
+              type: string
+            name:
+              _description: The name of the log file.
+              type: string
+            tags:
+              _description: Arbitrary tags and keywords that describe
+                this log.
+              type: array
+              items:
+                type: string
+            uri:
+              _description: The URI at which the log can be retrieved.
+              type: string
+          required:
+            - name
+            - uri
+          additionalProperties: false
+      customData:
+        type: array
+        items:
+          $ref: ../EiffelCustomDataProperty/2.0.0.yml
+    required:
+      - outcome
+    additionalProperties: false
+  links:
+    type: array
+    contains:
+      type: object
+      properties:
+        type:
+          enum:
+            - TEST_CASE_EXECUTION
+    items:
+      $ref: ../EiffelEventLink/2.0.0.yml
+required:
+  - meta
+  - data
+  - links
+additionalProperties: false
+_links:
+  CAUSE:
+    description: 'Identifies a cause of the event occurring. SHOULD
+      not be used in conjunction with __CONTEXT__: individual events
+      providing __CAUSE__ within a larger context gives rise to ambiguity.
+      It is instead recommended to let the root event of the context
+      declare __CAUSE__.'
+    required: false
+    multiple: true
+    targets:
+      any_type: true
+      types: []
+  CONTEXT:
+    description: Identifies the activity or test suite of which this
+      event constitutes a part.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelActivityTriggeredEvent
+        - EiffelTestSuiteStartedEvent
+  FLOW_CONTEXT:
+    description: 'Identifies the flow context of the event: which is
+      the continuous integration and delivery flow in which this occurred
+      – e.g. which product, project, track or version this is applicable
+      to.'
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelFlowContextDefinedEvent
+  TEST_CASE_EXECUTION:
+    description: Identifies the relevant test case execution. In other
+      words, [EiffelTestCaseTriggeredEvent](../eiffel-vocabulary/EiffelTestCaseTriggeredEvent.md)
+      acts as a handle for a particular test case execution. This differs
+      from __CONTEXT__. In __TEST_CASE_EXECUTION__ the source carries
+      information pertaining to the target (i.e. the test case execution
+      started, finished or was canceled). In __CONTEXT__, on the other
+      hand, the source constitutes a subset of the target (e.g. this
+      test case was executed as part of that activity or test suite).
+    required: true
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelTestCaseTriggeredEvent
+_history:
+  - version: 4.0.0
+    changes: Update meta schema to Draft 2020-12.
+  - version: 3.3.1
+    changes: Change IUT to Implementation Under Test (see [Issue 235](https://github.com/eiffel-community/eiffel/issues/359)).
+  - version: 3.3.0
+    introduced_in: edition-arica
+    changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
+  - version: 3.2.0
+    introduced_in: edition-lyon
+    changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
+  - version: 3.1.0
+    introduced_in: edition-lyon
+    changes: Add `data.persistentLogs.{mediaType,tags}`.
+  - version: 3.0.0
+    introduced_in: edition-agen
+    changes: Improved information integrity protection (see [Issue
+      185](https://github.com/eiffel-community/eiffel/issues/185)).
+  - version: 2.0.0
+    introduced_in: edition-agen
+    changes: Introduced purl identifiers instead of GAVs (see [Issue
+      182](https://github.com/eiffel-community/eiffel/issues/182))
+  - version: 1.1.0
+    introduced_in: edition-toulouse
+    changes: Multiple links of type FLOW_CONTEXT allowed.
+  - version: 1.0.1
+    introduced_in: edition-toulouse
+    changes: data.outcome.metrics.value and data.outcome.metrics.name
+      made mandatory.
+  - version: 1.0.0
+    introduced_in: edition-bordeaux
+    changes: Initial version.
+_examples:
+  - title: Simple example
+    url: ../examples/events/EiffelTestCaseFinishedEvent/simple.json

--- a/definitions/EiffelTestCaseStartedEvent/4.0.0.yml
+++ b/definitions/EiffelTestCaseStartedEvent/4.0.0.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-$schema: https://json-schema.org/draft/draft-2020-12/schema#
+$schema: https://json-schema.org/draft/2020-12/schema#
 _name: EiffelTestCaseStartedEvent
 _version: 4.0.0
 _abbrev: TCS
@@ -144,7 +144,7 @@ _links:
         - EiffelTestCaseTriggeredEvent
 _history:
   - version: 4.0.0
-    changes: Update meta schema to Draft 2020-12.
+    changes: Update meta schema to Draft 2020-12 and add link validation.
   - version: 3.3.0
     introduced_in: edition-arica
     changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).

--- a/definitions/EiffelTestCaseStartedEvent/4.0.0.yml
+++ b/definitions/EiffelTestCaseStartedEvent/4.0.0.yml
@@ -1,0 +1,173 @@
+# Copyright 2017-2024 Ericsson AB and others.
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+$schema: https://json-schema.org/draft/draft-2020-12/schema#
+_name: EiffelTestCaseStartedEvent
+_version: 4.0.0
+_abbrev: TCS
+_description: The EiffelTestCaseStartedEvent declares that the execution
+  of a test case has commenced. This event SHALL be preceded by a [EiffelTestCaseTriggeredEvent](./EiffelTestCaseTriggeredEvent.md),
+  and appropriately linked to via __TEST_CASE_EXECUTION__.
+type: object
+properties:
+  meta:
+    $ref: ../EiffelMetaProperty/4.0.0.yml
+  data:
+    type: object
+    properties:
+      executor:
+        _description: The name of the test case executor, if applicable.
+          This property can be used to identify tests executed by a
+          particular test framework.
+        type: string
+      liveLogs:
+        _description: An array of live log files available during execution.
+          These shall not be presumed to be stored persistently; in
+          other words, once the test case execution has finished there
+          is no guarantee that these links are valid. Persistently
+          stored logs shall be (re-)declared by [EiffelTestCaseFinishedEvent](./EiffelTestCaseFinishedEvent.md).
+        type: array
+        items:
+          type: object
+          properties:
+            mediaType:
+              _description: The [media type](https://en.wikipedia.org/wiki/Media_type)
+                of the URI's payload. Can be used to differentiate
+                between various representations of the same log, e.g.
+                text/html for human consumption and text/plain or application/json
+                for the machine-readable form.
+              type: string
+            name:
+              _description: The name of the log file.
+              type: string
+            tags:
+              _description: Arbitrary tags and keywords that describe
+                this log.
+              type: array
+              items:
+                type: string
+            uri:
+              _description: The URI at which the log can be retrieved.
+              type: string
+          required:
+            - name
+            - uri
+          additionalProperties: false
+      customData:
+        type: array
+        items:
+          $ref: ../EiffelCustomDataProperty/2.0.0.yml
+    additionalProperties: false
+  links:
+    type: array
+    contains:
+      type: object
+      properties:
+        type:
+          enum:
+            - TEST_CASE_EXECUTION
+    items:
+      $ref: ../EiffelEventLink/2.0.0.yml
+required:
+  - meta
+  - data
+  - links
+additionalProperties: false
+_links:
+  CAUSE:
+    description: 'Identifies a cause of the event occurring. SHOULD
+      not be used in conjunction with __CONTEXT__: individual events
+      providing __CAUSE__ within a larger context gives rise to ambiguity.
+      It is instead recommended to let the root event of the context
+      declare __CAUSE__.'
+    required: false
+    multiple: true
+    targets:
+      any_type: true
+      types: []
+  CONTEXT:
+    description: Identifies the activity or test suite of which this
+      event constitutes a part.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelActivityTriggeredEvent
+        - EiffelTestSuiteStartedEvent
+  ENVIRONMENT:
+    description: Identifies the environment in which the test case
+      is being executed.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelEnvironmentDefinedEvent
+  FLOW_CONTEXT:
+    description: 'Identifies the flow context of the event: which is
+      the continuous integration and delivery flow in which this occurred
+      – e.g. which product, project, track or version this is applicable
+      to.'
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelFlowContextDefinedEvent
+  TEST_CASE_EXECUTION:
+    description: Identifies the relevant test case execution. In other
+      words, [EiffelTestCaseTriggeredEvent](../eiffel-vocabulary/EiffelTestCaseTriggeredEvent.md)
+      acts as a handle for a particular test case execution. This differs
+      from __CONTEXT__. In __TEST_CASE_EXECUTION__ the source carries
+      information pertaining to the target (i.e. the test case execution
+      started, finished or was canceled). In __CONTEXT__, on the other
+      hand, the source constitutes a subset of the target (e.g. this
+      test case was executed as part of that activity or test suite).
+    required: true
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelTestCaseTriggeredEvent
+_history:
+  - version: 4.0.0
+    changes: Update meta schema to Draft 2020-12.
+  - version: 3.3.0
+    introduced_in: edition-arica
+    changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
+  - version: 3.2.0
+    introduced_in: edition-lyon
+    changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
+  - version: 3.1.0
+    introduced_in: edition-lyon
+    changes: Add `data.liveLogs.{mediaType,tags}`.
+  - version: 3.0.0
+    introduced_in: edition-agen
+    changes: Improved information integrity protection (see [Issue
+      185](https://github.com/eiffel-community/eiffel/issues/185)).
+  - version: 2.0.0
+    introduced_in: edition-agen
+    changes: Introduced purl identifiers instead of GAVs (see [Issue
+      182](https://github.com/eiffel-community/eiffel/issues/182))
+  - version: 1.1.0
+    introduced_in: edition-toulouse
+    changes: Multiple links of type FLOW_CONTEXT allowed.
+  - version: 1.0.0
+    introduced_in: edition-bordeaux
+    changes: Initial version.
+_examples:
+  - title: Simple example
+    url: ../examples/events/EiffelTestCaseStartedEvent/simple.json

--- a/definitions/EiffelTestCaseTriggeredEvent/4.0.0.yml
+++ b/definitions/EiffelTestCaseTriggeredEvent/4.0.0.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-$schema: https://json-schema.org/draft/draft-2020-12/schema#
+$schema: https://json-schema.org/draft/2020-12/schema#
 _name: EiffelTestCaseTriggeredEvent
 _version: 4.0.0
 _abbrev: TCT
@@ -210,7 +210,7 @@ _links:
         - EiffelTestCaseTriggeredEvent
 _history:
   - version: 4.0.0
-    changes: Update meta schema to Draft 2020-12.
+    changes: Update meta schema to Draft 2020-12 and add link validation.
   - version: 3.5.1
     changes: Change IUT to Implementation Under Test (see [Issue 235](https://github.com/eiffel-community/eiffel/issues/359)).
   - version: 3.5.0

--- a/definitions/EiffelTestCaseTriggeredEvent/4.0.0.yml
+++ b/definitions/EiffelTestCaseTriggeredEvent/4.0.0.yml
@@ -1,0 +1,249 @@
+# Copyright 2017-2024 Ericsson AB and others.
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+$schema: https://json-schema.org/draft/draft-2020-12/schema#
+_name: EiffelTestCaseTriggeredEvent
+_version: 4.0.0
+_abbrev: TCT
+_description: |-
+  The EiffelTestCaseTriggeredEvent declares that the execution of a test case has been triggered, but not yet started. This can either be declared stand-alone or as part of an activity or test suite, using either a __CAUSE__ or a __CONTEXT__ link type, respectively.
+
+  This event is used to communicate intent, and thereby serves a similar purpose to that of [EiffelActivityTriggeredEvent](./EiffelActivityTriggeredEvent.md). A triggered test case execution is expected to either be started (represented by [EiffelTestCaseStartedEvent](./EiffelTestCaseStartedEvent.md)) or canceled (represented by [EiffelTestCaseCanceledEvent](./EiffelTestCaseCanceledEvent.md)). Consequently, any delay between triggering and execution can be assumed to imply queuing time (e.g. waiting for available test resources) and monitored as such.
+type: object
+properties:
+  meta:
+    $ref: ../EiffelMetaProperty/4.0.0.yml
+  data:
+    type: object
+    properties:
+      testCase:
+        _description: Identification of the test case to be executed.
+        type: object
+        properties:
+          tracker:
+            _description: The name of the test case tracker - typically
+              a test management system.
+            type: string
+          id:
+            _description: The unique identity of the test case to be
+              executed.
+            type: string
+          version:
+            _description: The unique version of the identified test
+              case to be executed. Where this property is not used
+              it is assumed that test cases are not version controlled.
+            type: string
+          uri:
+            _description: A location where a description of the test
+              case can be retrieved. To the extent that multiple versions
+              of the same test case co-exist, this property SHALL identify
+              the exact version to be executed.
+            type: string
+        required:
+          - id
+        additionalProperties: false
+      recipeId:
+        _description: If triggering this test case execution was the
+          result of an Execution Recipe, as defined by an [EiffelTestExecutionRecipeCollectionCreatedEvent](./EiffelTestExecutionRecipeCollectionCreatedEvent.md),
+          this UUID SHALL match the relevant __data.batches.recipes.id__
+          in that event.
+        type: string
+        pattern: ^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$
+      triggers:
+        _description: The circumstances triggering the test case execution.
+        type: array
+        items:
+          type: object
+          properties:
+            type:
+              _description: |-
+                The type of trigger.
+                MANUAL signifies that the test case execution was manually triggered.  
+                EIFFEL_EVENT signifies that the test case execution was triggered by one or more Eiffel events. These events should be represented via __CAUSE__ links.  
+                SOURCE_CHANGE signifies that the test case execution was triggered as a consequence of a detected source change __not__ represented by Eiffel events.  
+                TIMER signifies that the test case execution was triggered by a timer.  
+                OTHER signifies any other triggering cause.
+              type: string
+              enum:
+                - MANUAL
+                - EIFFEL_EVENT
+                - SOURCE_CHANGE
+                - TIMER
+                - OTHER
+            description:
+              _description: A description of the trigger.
+              type: string
+          required:
+            - type
+          additionalProperties: false
+      executionType:
+        _description: The type of execution (often related to, but
+          ultimately separate from, __data.triggers.type__).
+        type: string
+        enum:
+          - MANUAL
+          - SEMI_AUTOMATED
+          - AUTOMATED
+          - OTHER
+      parameters:
+        _description: A list of parameters to be passed to the test
+          case execution.
+        type: array
+        items:
+          type: object
+          properties:
+            name:
+              _description: The name of the parameter.
+              type: string
+            value:
+              _description: The value of the parameter.
+              type: string
+          required:
+            - name
+            - value
+          additionalProperties: false
+      customData:
+        type: array
+        items:
+          $ref: ../EiffelCustomDataProperty/2.0.0.yml
+    required:
+      - testCase
+    additionalProperties: false
+  links:
+    type: array
+    contains:
+      type: object
+      properties:
+        type:
+          enum:
+            - IUT
+    items:
+      $ref: ../EiffelEventLink/2.0.0.yml
+required:
+  - meta
+  - data
+  - links
+additionalProperties: false
+_links:
+  CAUSE:
+    description: 'Identifies a cause of the event occurring. SHOULD
+      not be used in conjunction with __CONTEXT__: individual events
+      providing __CAUSE__ within a larger context gives rise to ambiguity.
+      It is instead recommended to let the root event of the context
+      declare __CAUSE__.'
+    required: false
+    multiple: true
+    targets:
+      any_type: true
+      types: []
+  CONTEXT:
+    description: Identifies the activity or test suite of which this
+      event constitutes a part.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelActivityTriggeredEvent
+        - EiffelTestSuiteStartedEvent
+  FLOW_CONTEXT:
+    description: 'Identifies the flow context of the event: which is
+      the continuous integration and delivery flow in which this occurred
+      – e.g. which product, project, track or version this is applicable
+      to.'
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelFlowContextDefinedEvent
+  IUT:
+    description: Identifies the Implementation Under Test; in other words, the
+      entity that is about to be tested.
+    required: true
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelArtifactCreatedEvent
+        - EiffelArtifactDeployedEvent
+        - EiffelCompositionDefinedEvent
+        - EiffelSourceChangeCreatedEvent
+        - EiffelSourceChangeSubmittedEvent
+  ORIGINAL_TRIGGER:
+    description: 'Used when the current test case execution is a new attempt
+      at completing a previous test case execution, typically because the
+      previous one failed. Although this activity may have been manually
+      triggered and thus lacks a cause that can be described with Eiffel,
+      this link can be used to convey the second-order cause.'
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelTestCaseTriggeredEvent
+  PRECURSOR:
+    description: 'Used to declare temporal relationships between
+      [activities](../eiffel-syntax-and-usage/glossary.md#activity) in a
+      [pipeline](../eiffel-syntax-and-usage/glossary.md#pipeline), i.e. what
+      other activity/activities preceded this activity. This link type applies
+      primarily to non event-triggered activities. For more information on
+      the usage of this link type please see
+      [Activity Linking](../eiffel-syntax-and-usage/activity-linking.md).'
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelTestCaseTriggeredEvent
+_history:
+  - version: 4.0.0
+    changes: Update meta schema to Draft 2020-12.
+  - version: 3.5.1
+    changes: Change IUT to Implementation Under Test (see [Issue 235](https://github.com/eiffel-community/eiffel/issues/359)).
+  - version: 3.5.0
+    introduced_in: edition-orizaba
+    changes: Add ORIGINAL_TRIGGER link (see [Issue 246](https://github.com/eiffel-community/eiffel/issues/246)).
+  - version: 3.4.0
+    introduced_in: edition-orizaba
+    changes: Add artifact deployed event as legal IUT target (see [Issue 239](https://github.com/eiffel-community/eiffel/issues/239)).
+  - version: 3.3.0
+    introduced_in: edition-orizaba
+    changes: Add SCS and SCC as legal target for IUT in TCT (see [Issue 317](https://github.com/eiffel-community/eiffel/issues/317)).
+  - version: 3.2.0
+    introduced_in: edition-arica
+    changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
+  - version: 3.1.0
+    introduced_in: edition-lyon
+    changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
+  - version: 3.0.0
+    introduced_in: edition-agen
+    changes: Improved information integrity protection (see [Issue
+      185](https://github.com/eiffel-community/eiffel/issues/185)).
+  - version: 2.0.0
+    introduced_in: edition-agen
+    changes: Introduced purl identifiers instead of GAVs (see [Issue
+      182](https://github.com/eiffel-community/eiffel/issues/182))
+  - version: 1.1.0
+    introduced_in: edition-toulouse
+    changes: Multiple links of type FLOW_CONTEXT allowed.
+  - version: 1.0.0
+    introduced_in: edition-bordeaux
+    changes: Initial version.
+_examples:
+  - title: Simple example
+    url: ../examples/events/EiffelTestCaseTriggeredEvent/simple.json
+  - title: Simple example using pre-3.0.0 meta.security object
+    url: ../examples/events/EiffelTestCaseTriggeredEvent/simple-2.0.0.json

--- a/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/5.0.0.yml
+++ b/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/5.0.0.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-$schema: https://json-schema.org/draft/draft-2020-12/schema#
+$schema: https://json-schema.org/draft/2020-12/schema#
 _name: EiffelTestExecutionRecipeCollectionCreatedEvent
 _version: 5.0.0
 _abbrev: TERCC
@@ -240,7 +240,7 @@ _links:
         - EiffelFlowContextDefinedEvent
 _history:
   - version: 5.0.0
-    changes: Update meta schema to Draft 2020-12.
+    changes: Update meta schema to Draft 2020-12 and add link validation.
   - version: 4.3.1
     changes: Change IUT to Implementation Under Test (see [Issue 235](https://github.com/eiffel-community/eiffel/issues/359)).
   - version: 4.3.0

--- a/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/5.0.0.yml
+++ b/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/5.0.0.yml
@@ -1,0 +1,284 @@
+# Copyright 2017-2024 Ericsson AB and others.
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+$schema: https://json-schema.org/draft/draft-2020-12/schema#
+_name: EiffelTestExecutionRecipeCollectionCreatedEvent
+_version: 5.0.0
+_abbrev: TERCC
+_description: |-
+  The EiffelTestExecutionRecipeCollectionCreatedEvent declares that a collection of test execution recipes has been created. In order to clarify what that means, several concepts need to be explained.
+
+  Just as Eiffel is an opinionated protocol, EiffelTestExecutionRecipeCollectionCreatedEvent is an opinionated event, and to a certain extent that opinion goes against the grain of traditional test management. This event assumes that activity configurations and test scope definitions are two separate things. To exemplify, when one's CI server triggers the Acceptance Test activity in the pipeline, there is nothing in that activity that says which tests to execute where or with what parameters: that is a separate concern. Instead, it will query a test selection service for that information. This information is encapsulated by the EiffelTestExecutionRecipeCollectionCreatedEvent, which contains all the information needed to configure and execute the tests.
+
+  How the test selection service generates the recipe collection is, from the point of view of the Eiffel protocol, irrelevant. It may very well be from a statically defined list of test cases, or from an elaborate test selection algorithm weighing together a host of factors to determine the optimal set of test cases to execute at any particular time, or a combination of the two.
+
+  The __data__ object consists of two main parts. __data.selectionStrategy__ identifies the strategy used to select the test cases and generate the recipe collection, while __data.batches__ or __data.batchesUri__ contain or reference, respectively, the recipes. The recipes are grouped in batches, which are used to control the order of execution of test cases. Every batch has a priority to let the test executor order them in sequence, but within each batch no assumptions are made as to the execution order the test cases. This way the recipe collection can either allow the executor a high degree of freedom in scheduling the test executions, and/or prescribe the exact sequential order in which they must be executed. Each event SHALL include one and only one of __data.batches__ and __data.batchesUri__.
+
+  Finally, each recipe (__data.batches.recipes__) consists of two parts: the test case to execute, and the constraints of that execution. The EiffelTestExecutionRecipeCollectionCreatedEvent does not control the syntax of these constraints, as the nature of such constraints are highly dependent on technology domain and test execution framework. That being said, there are three questions that typically need to be answered: what is the implementation under test, in what kind of environment is it to be tested, and what are the test parameters? Note the distinction between test case and test execution: it is perfectly legal for a single test case to appear multiple times within the same EiffelTestExecutionRecipeCollectionCreatedEvent, but (presumably) with different constraints.
+type: object
+properties:
+  meta:
+    $ref: ../EiffelMetaProperty/4.0.0.yml
+  data:
+    type: object
+    properties:
+      selectionStrategy:
+        _description: The strategy used to select the test cases and
+          generate the recipe collection.
+        type: object
+        properties:
+          tracker:
+            _description: The name of the selection strategy that generated
+              the test execution recipe collection.
+            type: string
+          id:
+            _description: The unique identity of the selection strategy
+              that generated the test execution recipe collection.
+            type: string
+          uri:
+            _description: The URI at which the the selection strategy
+              that generated the test execution recipe collection can
+              be retrieved.
+            type: string
+        required:
+          - id
+        additionalProperties: false
+      batchesUri:
+        _description: 'A URI at which at which the array of test execution
+          batches can be fetched. The format of the document at this
+          URI SHALL be on the format prescribed by __data.batches__
+          (i.e. ``` [ { "name": "Batch 1", ...}, {...}] ```). Each
+          event SHALL include one and only one of __data.batches__
+          and __data.batchesUri__.'
+        type: string
+      batches:
+        _description: A list of batches of recipes. Each event SHALL
+          include one and only one of __data.batches__ and __data.batchesUri__.
+          In the interest of keeping message sizes small, it is recommended
+          to use __data.batches__ only for limited numbers of test
+          cases (on the order of ten executions). For larger numbers
+          of executions, __data.batchesUri__ SHOULD be used instead.
+        type: array
+        items:
+          type: object
+          properties:
+            name:
+              _description: The name of the recipe batch.
+              type: string
+            priority:
+              _description: The execution priority of the batch, as
+                compared to other batches in the collection. A lower
+                value SHALL be interpreted as a higher priority.
+              type: integer
+            recipes:
+              _description: The collection of test execution recipes
+                within the batch.
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    _description: A UUID identifying the unique execution.
+                      Note that this is different from the id of a
+                      test case, in two ways. First, a test case is
+                      a (presumably) persistent entity, whereas an
+                      execution is transient in nature. Second, a test
+                      case may be executed any number of times in any
+                      given recipe collection.
+                    type: string
+                    pattern: ^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$
+                  testCase:
+                    _description: The test case to be executed in this
+                      execution recipe.
+                    type: object
+                    properties:
+                      tracker:
+                        _description: The name of the test case tracker
+                          - typically a test management system.
+                        type: string
+                      id:
+                        _description: The unique identity of the test
+                          case to be executed.
+                        type: string
+                      version:
+                        _description: The unique version of the identified
+                          test case to be executed. Where this property
+                          is not used it is assumed that test cases
+                          are not version controlled.
+                        type: string
+                      uri:
+                        _description: A location where a description
+                          of the test case can be retrieved. To the
+                          extent that multiple versions of the same
+                          test case co-exist, this property SHALL identify
+                          the exact version to be executed.
+                        type: string
+                    required:
+                      - id
+                    additionalProperties: false
+                  constraints:
+                    _description: 'Any constraints of the execution.
+                      The nature of such constraints is highly dependent
+                      on technology domain and test execution framework.
+                      Consequently, there are no pre-defined or required
+                      constraints. Instead, this property is a list
+                      of key-value pairs on the same format as [data.customData](../customization/custom-data.md).
+                      That being said, there are three questions that
+                      typically need to be answered: what is the implementation
+                      under test, in what kind of environment is it
+                      to be tested, and what are the test parameters?'
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          _description: The key name of constraint.
+                          type: string
+                        value:
+                          _description: The value of the constraint.
+                      required:
+                        - key
+                        - value
+                      additionalProperties: false
+                required:
+                  - id
+                  - testCase
+                additionalProperties: false
+            dependencies:
+              _description: A list of test case execution dependencies.
+                Ideally, test cases are atomic and can be executed
+                in isolation. In cases where a test case assumes that
+                another test case has been executed previously in the
+                same environment, however, this property can be used
+                to specify that. It serves as an instruction to the
+                test executor to place two executions subsequent to
+                one another in the same environment.
+              type: array
+              items:
+                type: object
+                properties:
+                  dependent:
+                    _description: The UUID of the dependent execution
+                      (__data.batches.recipes.id__), i.e. the execution
+                      that shall be performed only after that of the
+                      dependency.
+                    type: string
+                  dependency:
+                    _description: The UUID of the dependency execution
+                      (__data.batches.recipes.id__), i.e. the execution
+                      that shall be performed prior to that of the
+                      dependent.
+                    type: string
+                required:
+                  - dependent
+                  - dependency
+                additionalProperties: false
+          required:
+            - priority
+            - recipes
+          additionalProperties: false
+      customData:
+        type: array
+        items:
+          $ref: ../EiffelCustomDataProperty/2.0.0.yml
+    required:
+      - selectionStrategy
+    additionalProperties: false
+  links:
+    type: array
+    items:
+      $ref: ../EiffelEventLink/2.0.0.yml
+required:
+  - meta
+  - data
+  - links
+additionalProperties: false
+_links:
+  CAUSE:
+    description: 'Identifies a cause of the event occurring. SHOULD
+      not be used in conjunction with __CONTEXT__: individual events
+      providing __CAUSE__ within a larger context gives rise to ambiguity.
+      It is instead recommended to let the root event of the context
+      declare __CAUSE__.'
+    required: false
+    multiple: true
+    targets:
+      any_type: true
+      types: []
+  CONTEXT:
+    description: Identifies the activity or test suite of which this
+      event constitutes a part.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelActivityTriggeredEvent
+        - EiffelTestSuiteStartedEvent
+  FLOW_CONTEXT:
+    description: 'Identifies the flow context of the event: which is
+      the continuous integration and delivery flow in which this occurred
+      – e.g. which product, project, track or version this is applicable
+      to.'
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelFlowContextDefinedEvent
+_history:
+  - version: 5.0.0
+    changes: Update meta schema to Draft 2020-12.
+  - version: 4.3.1
+    changes: Change IUT to Implementation Under Test (see [Issue 235](https://github.com/eiffel-community/eiffel/issues/359)).
+  - version: 4.3.0
+    introduced_in: edition-arica
+    changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
+  - version: 4.2.0
+    introduced_in: edition-arica
+    changes: Add missing testCase.version member (see [Issue 288](https://github.com/eiffel-community/eiffel/issues/288)).
+  - version: 4.1.1
+    introduced_in: edition-lyon
+    changes: Add missing validation pattern to links.target member
+      (see [Issue 271](https://github.com/eiffel-community/eiffel/issues/271)).
+  - version: 4.1.0
+    introduced_in: edition-lyon
+    changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
+  - version: 4.0.0
+    introduced_in: edition-agen
+    changes: Improved information integrity protection (see [Issue
+      185](https://github.com/eiffel-community/eiffel/issues/185)).
+  - version: 3.0.0
+    introduced_in: edition-agen
+    changes: Introduced purl identifiers instead of GAVs (see [Issue
+      182](https://github.com/eiffel-community/eiffel/issues/182))
+  - version: 2.1.0
+    introduced_in: edition-toulouse
+    changes: Multiple links of type FLOW_CONTEXT allowed.
+  - version: 2.0.0
+    introduced_in: edition-toulouse
+    changes: Changed syntax of data.batches.recipes.constraints from
+      an uncontrolled object to a list of key-value pairs to comply
+      with design guidelines.
+  - version: 1.0.0
+    introduced_in: edition-bordeaux
+    changes: Initial version.
+_examples:
+  - title: Example using data.batches
+    url: ../examples/events/EiffelTestExecutionRecipeCollectionCreatedEvent/batches.json
+  - title: Example using data.batches (1.0.0 syntax)
+    url: ../examples/events/EiffelTestExecutionRecipeCollectionCreatedEvent/batches-1.0.0.json
+  - title: Example using data.batchesUri
+    url: ../examples/events/EiffelTestExecutionRecipeCollectionCreatedEvent/batchesUri.json

--- a/definitions/EiffelTestSuiteFinishedEvent/4.0.0.yml
+++ b/definitions/EiffelTestSuiteFinishedEvent/4.0.0.yml
@@ -1,0 +1,189 @@
+# Copyright 2017-2024 Ericsson AB and others.
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+$schema: https://json-schema.org/draft/draft-2020-12/schema#
+_name: EiffelTestSuiteFinishedEvent
+_version: 4.0.0
+_abbrev: TSF
+_description: |-
+  The EiffelTestSuiteFinishedEvent declares that a previously started test suite (declared by [EiffelTestSuiteStartedEvent](./EiffelTestSuiteStartedEvent.md)) has finished and reports the outcome.
+
+  Note that while similar, the __data.outcome__ object is different from that of [EiffelActivityFinishedEvent](./EiffelActivityFinishedEvent.md). The outcome of the test suite reports not only the conclusion of the test suite execution - whether the tests were successfully executed - but also passes a verdict on the item or items under test. To highlight this conceptual difference, both __data.outcome.verdict__ and __data.outcome.conclusion__ are included.
+type: object
+properties:
+  meta:
+    $ref: ../EiffelMetaProperty/4.0.0.yml
+  data:
+    type: object
+    properties:
+      outcome:
+        _description: The outcome of the test suite.
+        type: object
+        properties:
+          verdict:
+            _description: |-
+              A terse standardized verdict on the item or items under test. Unlike in [EiffelTestCaseFinishedEvent](./EiffelTestCaseFinishedEvent.md), this property is optional. It offers a method of summarizing the verdict of the test suite as a whole, but may be skipped.
+              PASSED signifies that the item or items under test successfully passed the test suite.  
+              FAILED signifies that the item or items under test failed to pass the test suite.  
+              INCONCLUSIVE signifies that the verdict of the test suite was inconclusive. This SHOULD be the case if __data.outcome.conclusion__ is not __SUCCESSFUL__, but may in combination with a __SUCCESSFUL__ conclusion be used to represent unreliability or flakiness.
+            type: string
+            enum:
+              - PASSED
+              - FAILED
+              - INCONCLUSIVE
+          conclusion:
+            _description: |-
+              A terse standardized conclusion of the test suite, designed to be machine readable. Unlike in [EiffelTestCaseFinishedEvent](./EiffelTestCaseFinishedEvent.md), this property is optional. It offers a method of summarizing the conclusion of the test suite as a whole, but may be skipped.
+              SUCCESSFUL signifies that the test suite was successfully concluded. Note that this does not imply that the implementation under test passed the tests.  
+              FAILED signifies that the test suite could not be successfully executed. To exemplify, one or more tests failed to run due to required environments being unavailable.  
+              ABORTED signifies that the test suite was aborted before it could be concluded.  
+              TIMED_OUT signifies that the test suite did not conclude within the allowed time frame.  
+              INCONCLUSIVE signifies that the outcome of the test suite could not be determined.
+            type: string
+            enum:
+              - SUCCESSFUL
+              - FAILED
+              - ABORTED
+              - TIMED_OUT
+              - INCONCLUSIVE
+          description:
+            _description: A verbose description of the test suite outcome,
+              designed to provide human readers with further information.
+            type: string
+        additionalProperties: false
+      persistentLogs:
+        _description: An array of persistent log files generated during
+          execution.
+        type: array
+        items:
+          type: object
+          properties:
+            mediaType:
+              _description: The [media type](https://en.wikipedia.org/wiki/Media_type)
+                of the URI's payload. Can be used to differentiate
+                between various representations of the same log, e.g.
+                text/html for human consumption and text/plain or application/json
+                for the machine-readable form.
+              type: string
+            name:
+              _description: The name of the log file.
+              type: string
+            tags:
+              _description: Arbitrary tags and keywords that describe
+                this log.
+              type: array
+              items:
+                type: string
+            uri:
+              _description: The URI at which the log can be retrieved.
+              type: string
+          required:
+            - name
+            - uri
+          additionalProperties: false
+      customData:
+        type: array
+        items:
+          $ref: ../EiffelCustomDataProperty/2.0.0.yml
+    additionalProperties: false
+  links:
+    type: array
+    contains:
+      type: object
+      properties:
+        type:
+          enum:
+            - TEST_SUITE_EXECUTION
+    items:
+      $ref: ../EiffelEventLink/2.0.0.yml
+required:
+  - meta
+  - data
+  - links
+additionalProperties: false
+_links:
+  CAUSE:
+    description: 'Identifies a cause of the event occurring. SHOULD
+      not be used in conjunction with __CONTEXT__: individual events
+      providing __CAUSE__ within a larger context gives rise to ambiguity.
+      It is instead recommended to let the root event of the context
+      declare __CAUSE__.'
+    required: false
+    multiple: true
+    targets:
+      any_type: true
+      types: []
+  CONTEXT:
+    description: Identifies the activity or test suite of which this
+      event constitutes a part.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelActivityTriggeredEvent
+        - EiffelTestSuiteStartedEvent
+  FLOW_CONTEXT:
+    description: 'Identifies the flow context of the event: which is
+      the continuous integration and delivery flow in which this occurred
+      – e.g. which product, project, track or version this is applicable
+      to.'
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelFlowContextDefinedEvent
+  TEST_SUITE_EXECUTION:
+    description: Identifies the relevant test suite execution. In other
+      words, [EiffelTestSuiteStartedEvent](../eiffel-vocabulary/EiffelTestSuiteStartedEvent.md)
+      acts as a handle for a particular test suite execution.
+    required: true
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelTestSuiteStartedEvent
+_history:
+  - version: 4.0.0
+    changes: Update meta schema to Draft 2020-12.
+  - version: 3.3.1
+    changes: Change IUT to Implementation Under Test (see [Issue 235](https://github.com/eiffel-community/eiffel/issues/359)).
+  - version: 3.3.0
+    introduced_in: edition-arica
+    changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
+  - version: 3.2.0
+    introduced_in: edition-lyon
+    changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
+  - version: 3.1.0
+    introduced_in: edition-lyon
+    changes: Add `data.persistentLogs.{mediaType,tags}`.
+  - version: 3.0.0
+    introduced_in: edition-agen
+    changes: Improved information integrity protection (see [Issue
+      185](https://github.com/eiffel-community/eiffel/issues/185)).
+  - version: 2.0.0
+    introduced_in: edition-agen
+    changes: Introduced purl identifiers instead of GAVs (see [Issue
+      182](https://github.com/eiffel-community/eiffel/issues/182))
+  - version: 1.1.0
+    introduced_in: edition-toulouse
+    changes: Multiple links of type FLOW_CONTEXT allowed.
+  - version: 1.0.0
+    introduced_in: edition-bordeaux
+    changes: Initial version.
+_examples:
+  - title: Simple example
+    url: ../examples/events/EiffelTestSuiteFinishedEvent/simple.json

--- a/definitions/EiffelTestSuiteFinishedEvent/4.0.0.yml
+++ b/definitions/EiffelTestSuiteFinishedEvent/4.0.0.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-$schema: https://json-schema.org/draft/draft-2020-12/schema#
+$schema: https://json-schema.org/draft/2020-12/schema#
 _name: EiffelTestSuiteFinishedEvent
 _version: 4.0.0
 _abbrev: TSF
@@ -158,7 +158,7 @@ _links:
         - EiffelTestSuiteStartedEvent
 _history:
   - version: 4.0.0
-    changes: Update meta schema to Draft 2020-12.
+    changes: Update meta schema to Draft 2020-12 and add link validation.
   - version: 3.3.1
     changes: Change IUT to Implementation Under Test (see [Issue 235](https://github.com/eiffel-community/eiffel/issues/359)).
   - version: 3.3.0

--- a/definitions/EiffelTestSuiteStartedEvent/4.0.0.yml
+++ b/definitions/EiffelTestSuiteStartedEvent/4.0.0.yml
@@ -1,0 +1,217 @@
+# Copyright 2017-2024 Ericsson AB and others.
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+$schema: https://json-schema.org/draft/draft-2020-12/schema#
+_name: EiffelTestSuiteStartedEvent
+_version: 4.0.0
+_abbrev: TSS
+_description: |-
+  The EiffelTestSuiteStartedEvent declares that the execution of a test suite has started. This can either be declared stand-alone or as part of an activity or other test suite, using either a __CAUSE__ or a __CONTEXT__ link type, respectively.
+
+  In Eiffel, a test suite is nothing more or less than a collection of test case executions (see [EiffelTestCaseStartedEvent](./EiffelTestCaseStartedEvent.md)) and/or other test suite executions. The executed test suite may be an ad-hoc transient grouping of test cases that were executed at a particular time or place or for a particular purpose or a persistent entity tracked in a test management system - Eiffel makes no distinction or assumptions either way.
+type: object
+properties:
+  meta:
+    $ref: ../EiffelMetaProperty/4.0.0.yml
+  data:
+    type: object
+    properties:
+      name:
+        _description: The name of the test suite. Uniqueness is not
+          required or checked, but is useful.
+        type: string
+      categories:
+        _description: The category or categories of the test suite.
+          This can be used to group multiple similar test suites for
+          analysis and visualization purposes. Example usage is to
+          categorize test suites required before release as "Pre-release
+          tests".
+        type: array
+        items:
+          type: string
+      types:
+        _description: The type or types of testing performed by the
+          test suite, as [defined by ISO 29119](http://www.softwaretestingstandard.org).
+        type: array
+        items:
+          type: string
+          enum:
+            - ACCESSIBILITY
+            - BACKUP_RECOVERY
+            - COMPATIBILITY
+            - CONVERSION
+            - DISASTER_RECOVERY
+            - FUNCTIONAL
+            - INSTALLABILITY
+            - INTEROPERABILITY
+            - LOCALIZATION
+            - MAINTAINABILITY
+            - PERFORMANCE
+            - PORTABILITY
+            - PROCEDURE
+            - RELIABILITY
+            - SECURITY
+            - STABILITY
+            - USABILITY
+      liveLogs:
+        _description: An array of live log files available during execution.
+          These shall not be presumed to be stored persistently; in
+          other words, once the test suite has finished there is no
+          guarantee that these links are valid. Persistently stored
+          logs shall be (re-)declared by [EiffelTestSuiteFinishedEvent](./EiffelTestSuiteFinishedEvent.md).
+        type: array
+        items:
+          type: object
+          properties:
+            mediaType:
+              _description: The [media type](https://en.wikipedia.org/wiki/Media_type)
+                of the URI's payload. Can be used to differentiate
+                between various representations of the same log, e.g.
+                text/html for human consumption and text/plain or application/json
+                for the machine-readable form.
+              type: string
+            name:
+              _description: The name of the log file.
+              type: string
+            tags:
+              _description: Arbitrary tags and keywords that describe
+                this log.
+              type: array
+              items:
+                type: string
+            uri:
+              _description: The URI at which the log can be retrieved.
+              type: string
+          required:
+            - name
+            - uri
+          additionalProperties: false
+      customData:
+        type: array
+        items:
+          $ref: ../EiffelCustomDataProperty/2.0.0.yml
+    required:
+      - name
+    additionalProperties: false
+  links:
+    type: array
+    items:
+      $ref: ../EiffelEventLink/2.0.0.yml
+required:
+  - meta
+  - data
+  - links
+additionalProperties: false
+_links:
+  CAUSE:
+    description: 'Identifies a cause of the event occurring. SHOULD
+      not be used in conjunction with __CONTEXT__: individual events
+      providing __CAUSE__ within a larger context gives rise to ambiguity.
+      It is instead recommended to let the root event of the context
+      declare __CAUSE__.'
+    required: false
+    multiple: true
+    targets:
+      any_type: true
+      types: []
+  CONTEXT:
+    description: Identifies the activity or test suite of which this
+      event constitutes a part.
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelActivityTriggeredEvent
+        - EiffelTestSuiteStartedEvent
+  FLOW_CONTEXT:
+    description: 'Identifies the flow context of the event: which is
+      the continuous integration and delivery flow in which this occurred
+      – e.g. which product, project, track or version this is applicable
+      to.'
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelFlowContextDefinedEvent
+  ORIGINAL_TRIGGER:
+    description: 'Used when the current test suite execution is a new attempt
+      at completing a previous test suite execution, typically because the
+      previous one failed. Although this activity may have been manually triggered
+      and thus lacks a cause that can be described with Eiffel, this link can
+      be used to convey the second-order cause.'
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelTestSuiteStartedEvent
+  PRECURSOR:
+    description: 'Used to declare temporal relationships between
+      [activities](../eiffel-syntax-and-usage/glossary.md#activity) in a
+      [pipeline](../eiffel-syntax-and-usage/glossary.md#pipeline), i.e. what
+      other activity/activities preceded this activity. This link type applies
+      primarily to non event-triggered activities. For more information on
+      the usage of this link type please see
+      [Activity Linking](../eiffel-syntax-and-usage/activity-linking.md).'
+    required: false
+    multiple: true
+    targets:
+      any_type: false
+      types:
+        - EiffelTestSuiteStartedEvent
+  TERC:
+    description: This link signifies that the test suite represented
+      by this event groups all test case executions resulting from
+      the [EiffelTestExecutionRecipeCollectionCreatedEvent](../eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md).
+    required: false
+    multiple: false
+    targets:
+      any_type: false
+      types:
+        - EiffelTestExecutionRecipeCollectionCreatedEvent
+_history:
+  - version: 4.0.0
+    changes: Update meta schema to Draft 2020-12.
+  - version: 3.4.0
+    introduced_in: edition-orizaba
+    changes: Add ORIGINAL_TRIGGER link (see [Issue 246](https://github.com/eiffel-community/eiffel/issues/246)).
+  - version: 3.3.0
+    introduced_in: edition-arica
+    changes: Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)).
+  - version: 3.2.0
+    introduced_in: edition-lyon
+    changes: Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)).
+  - version: 3.1.0
+    introduced_in: edition-lyon
+    changes: Add `data.liveLogs.{mediaType,tags}`.
+  - version: 3.0.0
+    introduced_in: edition-agen
+    changes: Improved information integrity protection (see [Issue
+      185](https://github.com/eiffel-community/eiffel/issues/185)).
+  - version: 2.0.0
+    introduced_in: edition-agen
+    changes: Introduced purl identifiers instead of GAVs (see [Issue
+      182](https://github.com/eiffel-community/eiffel/issues/182))
+  - version: 1.1.0
+    introduced_in: edition-toulouse
+    changes: Multiple links of type FLOW_CONTEXT allowed.
+  - version: 1.0.0
+    introduced_in: edition-bordeaux
+    changes: Initial version.
+_examples:
+  - title: Simple example
+    url: ../examples/events/EiffelTestSuiteStartedEvent/simple.json

--- a/definitions/EiffelTestSuiteStartedEvent/4.0.0.yml
+++ b/definitions/EiffelTestSuiteStartedEvent/4.0.0.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-$schema: https://json-schema.org/draft/draft-2020-12/schema#
+$schema: https://json-schema.org/draft/2020-12/schema#
 _name: EiffelTestSuiteStartedEvent
 _version: 4.0.0
 _abbrev: TSS
@@ -185,7 +185,7 @@ _links:
         - EiffelTestExecutionRecipeCollectionCreatedEvent
 _history:
   - version: 4.0.0
-    changes: Update meta schema to Draft 2020-12.
+    changes: Update meta schema to Draft 2020-12 and add link validation.
   - version: 3.4.0
     introduced_in: edition-orizaba
     changes: Add ORIGINAL_TRIGGER link (see [Issue 246](https://github.com/eiffel-community/eiffel/issues/246)).

--- a/diff_definitions.py
+++ b/diff_definitions.py
@@ -53,9 +53,10 @@ def _main():
             print(
                 f"diff -u definitions/{type}/{base_version}.yml definitions/{type}/{workspace_version}.yml"
             )
-            print(
-                f"diff -u schemas/{type}/{base_version}.json schemas/{type}/{workspace_version}.json"
-            )
+            if type.endswith("Event"):
+                print(
+                    f"diff -u schemas/{type}/{base_version}.json schemas/{type}/{workspace_version}.json"
+                )
 
 
 if __name__ == "__main__":

--- a/eiffel-vocabulary/EiffelActivityCanceledEvent.md
+++ b/eiffel-vocabulary/EiffelActivityCanceledEvent.md
@@ -1,5 +1,5 @@
 <!---
-   This file was generated from ../definitions/EiffelActivityCanceledEvent/4.0.0.yml.
+   This file was generated from ../definitions/EiffelActivityCanceledEvent/5.0.0.yml.
    See that file for a copyright notice.
 --->
 
@@ -177,6 +177,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
+| 5.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
 | 4.0.0 | Not yet released in an edition | Fix bug in schema regarding additionalProperties (see [Issue 376](https://github.com/eiffel-community/eiffel/issues/376)). |
 | 3.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |

--- a/eiffel-vocabulary/EiffelActivityCanceledEvent.md
+++ b/eiffel-vocabulary/EiffelActivityCanceledEvent.md
@@ -177,7 +177,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
-| 5.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
+| 5.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12 and add link validation. |
 | 4.0.0 | Not yet released in an edition | Fix bug in schema regarding additionalProperties (see [Issue 376](https://github.com/eiffel-community/eiffel/issues/376)). |
 | 3.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |

--- a/eiffel-vocabulary/EiffelActivityFinishedEvent.md
+++ b/eiffel-vocabulary/EiffelActivityFinishedEvent.md
@@ -219,7 +219,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
-| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12 and add link validation. |
 | 3.3.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.2.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add `data.persistentLogs.{mediaType,tags}`. |

--- a/eiffel-vocabulary/EiffelActivityFinishedEvent.md
+++ b/eiffel-vocabulary/EiffelActivityFinishedEvent.md
@@ -1,5 +1,5 @@
 <!---
-   This file was generated from ../definitions/EiffelActivityFinishedEvent/3.3.0.yml.
+   This file was generated from ../definitions/EiffelActivityFinishedEvent/4.0.0.yml.
    See that file for a copyright notice.
 --->
 
@@ -219,6 +219,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
 | 3.3.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.2.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add `data.persistentLogs.{mediaType,tags}`. |

--- a/eiffel-vocabulary/EiffelActivityStartedEvent.md
+++ b/eiffel-vocabulary/EiffelActivityStartedEvent.md
@@ -1,5 +1,5 @@
 <!---
-   This file was generated from ../definitions/EiffelActivityStartedEvent/4.3.0.yml.
+   This file was generated from ../definitions/EiffelActivityStartedEvent/5.0.0.yml.
    See that file for a copyright notice.
 --->
 
@@ -208,6 +208,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
+| 5.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
 | 4.3.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 4.2.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 4.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add `data.liveLogs.{mediaType,tags}`. |

--- a/eiffel-vocabulary/EiffelActivityStartedEvent.md
+++ b/eiffel-vocabulary/EiffelActivityStartedEvent.md
@@ -208,7 +208,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
-| 5.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
+| 5.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12 and add link validation. |
 | 4.3.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 4.2.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 4.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add `data.liveLogs.{mediaType,tags}`. |

--- a/eiffel-vocabulary/EiffelActivityTriggeredEvent.md
+++ b/eiffel-vocabulary/EiffelActivityTriggeredEvent.md
@@ -217,7 +217,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
-| 5.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
+| 5.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12 and add link validation. |
 | 4.3.0 | [edition-orizaba](../../../tree/edition-orizaba) | Add ORIGINAL_TRIGGER link (see [Issue 246](https://github.com/eiffel-community/eiffel/issues/246)). |
 | 4.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 4.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |

--- a/eiffel-vocabulary/EiffelActivityTriggeredEvent.md
+++ b/eiffel-vocabulary/EiffelActivityTriggeredEvent.md
@@ -1,5 +1,5 @@
 <!---
-   This file was generated from ../definitions/EiffelActivityTriggeredEvent/4.3.0.yml.
+   This file was generated from ../definitions/EiffelActivityTriggeredEvent/5.0.0.yml.
    See that file for a copyright notice.
 --->
 
@@ -217,6 +217,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
+| 5.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
 | 4.3.0 | [edition-orizaba](../../../tree/edition-orizaba) | Add ORIGINAL_TRIGGER link (see [Issue 246](https://github.com/eiffel-community/eiffel/issues/246)). |
 | 4.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 4.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |

--- a/eiffel-vocabulary/EiffelAnnouncementPublishedEvent.md
+++ b/eiffel-vocabulary/EiffelAnnouncementPublishedEvent.md
@@ -193,7 +193,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
-| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12 and add link validation. |
 | 3.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |

--- a/eiffel-vocabulary/EiffelAnnouncementPublishedEvent.md
+++ b/eiffel-vocabulary/EiffelAnnouncementPublishedEvent.md
@@ -1,5 +1,5 @@
 <!---
-   This file was generated from ../definitions/EiffelAnnouncementPublishedEvent/3.2.0.yml.
+   This file was generated from ../definitions/EiffelAnnouncementPublishedEvent/4.0.0.yml.
    See that file for a copyright notice.
 --->
 
@@ -193,6 +193,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
 | 3.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |

--- a/eiffel-vocabulary/EiffelArtifactCreatedEvent.md
+++ b/eiffel-vocabulary/EiffelArtifactCreatedEvent.md
@@ -255,7 +255,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
-| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12 and add link validation. |
 | 3.3.0 | [edition-arica](../../../tree/edition-arica) | Added data.fileInformation.integrityProtection member (see [Issue 290](https://github.com/eiffel-community/eiffel/issues/290)). |
 | 3.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |

--- a/eiffel-vocabulary/EiffelArtifactCreatedEvent.md
+++ b/eiffel-vocabulary/EiffelArtifactCreatedEvent.md
@@ -1,5 +1,5 @@
 <!---
-   This file was generated from ../definitions/EiffelArtifactCreatedEvent/3.3.0.yml.
+   This file was generated from ../definitions/EiffelArtifactCreatedEvent/4.0.0.yml.
    See that file for a copyright notice.
 --->
 
@@ -255,6 +255,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
 | 3.3.0 | [edition-arica](../../../tree/edition-arica) | Added data.fileInformation.integrityProtection member (see [Issue 290](https://github.com/eiffel-community/eiffel/issues/290)). |
 | 3.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |

--- a/eiffel-vocabulary/EiffelArtifactDeployedEvent.md
+++ b/eiffel-vocabulary/EiffelArtifactDeployedEvent.md
@@ -196,7 +196,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
-| 0.2.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
+| 0.2.0 | Not yet released in an edition | Update meta schema to Draft 2020-12 and add link validation. |
 | 0.1.0 | [edition-orizaba](../../../tree/edition-orizaba) | Initial version. |
 
 ## Examples

--- a/eiffel-vocabulary/EiffelArtifactDeployedEvent.md
+++ b/eiffel-vocabulary/EiffelArtifactDeployedEvent.md
@@ -1,10 +1,10 @@
 <!---
-   This file was generated from ../definitions/EiffelArtifactDeployedEvent/0.1.0.yml.
+   This file was generated from ../definitions/EiffelArtifactDeployedEvent/0.2.0.yml.
    See that file for a copyright notice.
 --->
 
 # EiffelArtifactDeployedEvent (ArtD)
-> :warning: This event type is currently at version 0.1.0 and is therefore experimental. Until it has reached version 1.0.0 it may undergo any number of backwards incompatible changes. It might also be deprecated and never reach 1.0.0.
+> :warning: This event type is currently at version 0.2.0 and is therefore experimental. Until it has reached version 1.0.0 it may undergo any number of backwards incompatible changes. It might also be deprecated and never reach 1.0.0.
 
 The EiffelArtifactDeployedEvent states that a software artifact had been deployed into a specified environment or that the configuration of the artifact has been changed. The exact meaning of an artifact deployment is implementation-defined. Progressive deployments like e.g. canaries can be described with an EiffelArtifactDeployedEvent every time the deployment advances or a single EiffelArtifactDeployedEvent once the artifact has been fully deployed.
 
@@ -196,6 +196,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
+| 0.2.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
 | 0.1.0 | [edition-orizaba](../../../tree/edition-orizaba) | Initial version. |
 
 ## Examples

--- a/eiffel-vocabulary/EiffelArtifactPublishedEvent.md
+++ b/eiffel-vocabulary/EiffelArtifactPublishedEvent.md
@@ -1,5 +1,5 @@
 <!---
-   This file was generated from ../definitions/EiffelArtifactPublishedEvent/3.3.0.yml.
+   This file was generated from ../definitions/EiffelArtifactPublishedEvent/4.0.0.yml.
    See that file for a copyright notice.
 --->
 
@@ -197,6 +197,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
 | 3.3.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.2.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.1.0 | [edition-paris](../../../tree/edition-paris) | Added name qualifier for artifact locations (see [Issue 248](https://github.com/eiffel-community/eiffel/issues/248)) |

--- a/eiffel-vocabulary/EiffelArtifactPublishedEvent.md
+++ b/eiffel-vocabulary/EiffelArtifactPublishedEvent.md
@@ -197,7 +197,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
-| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12 and add link validation. |
 | 3.3.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.2.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.1.0 | [edition-paris](../../../tree/edition-paris) | Added name qualifier for artifact locations (see [Issue 248](https://github.com/eiffel-community/eiffel/issues/248)) |

--- a/eiffel-vocabulary/EiffelArtifactReusedEvent.md
+++ b/eiffel-vocabulary/EiffelArtifactReusedEvent.md
@@ -1,5 +1,5 @@
 <!---
-   This file was generated from ../definitions/EiffelArtifactReusedEvent/3.2.0.yml.
+   This file was generated from ../definitions/EiffelArtifactReusedEvent/4.0.0.yml.
    See that file for a copyright notice.
 --->
 
@@ -180,6 +180,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
 | 3.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |

--- a/eiffel-vocabulary/EiffelArtifactReusedEvent.md
+++ b/eiffel-vocabulary/EiffelArtifactReusedEvent.md
@@ -180,7 +180,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
-| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12 and add link validation. |
 | 3.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |

--- a/eiffel-vocabulary/EiffelCompositionDefinedEvent.md
+++ b/eiffel-vocabulary/EiffelCompositionDefinedEvent.md
@@ -188,7 +188,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
-| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12 and add link validation. |
 | 3.3.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.2.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.1.0 | [edition-paris](../../../tree/edition-paris) | Added SCC as valid target for ELEMENT links (see [Issue 218](https://github.com/eiffel-community/eiffel/issues/218)) |

--- a/eiffel-vocabulary/EiffelCompositionDefinedEvent.md
+++ b/eiffel-vocabulary/EiffelCompositionDefinedEvent.md
@@ -1,5 +1,5 @@
 <!---
-   This file was generated from ../definitions/EiffelCompositionDefinedEvent/3.3.0.yml.
+   This file was generated from ../definitions/EiffelCompositionDefinedEvent/4.0.0.yml.
    See that file for a copyright notice.
 --->
 
@@ -188,6 +188,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
 | 3.3.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.2.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.1.0 | [edition-paris](../../../tree/edition-paris) | Added SCC as valid target for ELEMENT links (see [Issue 218](https://github.com/eiffel-community/eiffel/issues/218)) |

--- a/eiffel-vocabulary/EiffelConfidenceLevelModifiedEvent.md
+++ b/eiffel-vocabulary/EiffelConfidenceLevelModifiedEvent.md
@@ -225,7 +225,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
-| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12 and add link validation. |
 | 3.4.0 | Not yet released in an edition | Add CONFIDENCE_BASIS link (see [Issue 323](https://github.com/eiffel-community/eiffel/issues/323)). |
 | 3.3.0 | [edition-orizaba](../../../tree/edition-orizaba) | Add EiffelArtifactDeployedEvent as legal target type for SUBJECT link (see [Issue 239](https://github.com/eiffel-community/eiffel/issues/239)). |
 | 3.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |

--- a/eiffel-vocabulary/EiffelConfidenceLevelModifiedEvent.md
+++ b/eiffel-vocabulary/EiffelConfidenceLevelModifiedEvent.md
@@ -1,5 +1,5 @@
 <!---
-   This file was generated from ../definitions/EiffelConfidenceLevelModifiedEvent/3.4.0.yml.
+   This file was generated from ../definitions/EiffelConfidenceLevelModifiedEvent/4.0.0.yml.
    See that file for a copyright notice.
 --->
 
@@ -225,6 +225,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
 | 3.4.0 | Not yet released in an edition | Add CONFIDENCE_BASIS link (see [Issue 323](https://github.com/eiffel-community/eiffel/issues/323)). |
 | 3.3.0 | [edition-orizaba](../../../tree/edition-orizaba) | Add EiffelArtifactDeployedEvent as legal target type for SUBJECT link (see [Issue 239](https://github.com/eiffel-community/eiffel/issues/239)). |
 | 3.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |

--- a/eiffel-vocabulary/EiffelEnvironmentDefinedEvent.md
+++ b/eiffel-vocabulary/EiffelEnvironmentDefinedEvent.md
@@ -1,5 +1,5 @@
 <!---
-   This file was generated from ../definitions/EiffelEnvironmentDefinedEvent/3.3.0.yml.
+   This file was generated from ../definitions/EiffelEnvironmentDefinedEvent/4.0.0.yml.
    See that file for a copyright notice.
 --->
 
@@ -215,6 +215,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
 | 3.3.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.2.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Added RUNTIME_ENVIRONMENT link type. |

--- a/eiffel-vocabulary/EiffelEnvironmentDefinedEvent.md
+++ b/eiffel-vocabulary/EiffelEnvironmentDefinedEvent.md
@@ -215,7 +215,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
-| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12 and add link validation. |
 | 3.3.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.2.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Added RUNTIME_ENVIRONMENT link type. |

--- a/eiffel-vocabulary/EiffelFlowContextDefinedEvent.md
+++ b/eiffel-vocabulary/EiffelFlowContextDefinedEvent.md
@@ -1,5 +1,5 @@
 <!---
-   This file was generated from ../definitions/EiffelFlowContextDefinedEvent/3.2.0.yml.
+   This file was generated from ../definitions/EiffelFlowContextDefinedEvent/4.0.0.yml.
    See that file for a copyright notice.
 --->
 
@@ -193,6 +193,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
 | 3.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |

--- a/eiffel-vocabulary/EiffelFlowContextDefinedEvent.md
+++ b/eiffel-vocabulary/EiffelFlowContextDefinedEvent.md
@@ -193,7 +193,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
-| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12 and add link validation. |
 | 3.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |

--- a/eiffel-vocabulary/EiffelIssueDefinedEvent.md
+++ b/eiffel-vocabulary/EiffelIssueDefinedEvent.md
@@ -1,5 +1,5 @@
 <!---
-   This file was generated from ../definitions/EiffelIssueDefinedEvent/3.2.0.yml.
+   This file was generated from ../definitions/EiffelIssueDefinedEvent/4.0.0.yml.
    See that file for a copyright notice.
 --->
 
@@ -204,6 +204,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
 | 3.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |

--- a/eiffel-vocabulary/EiffelIssueDefinedEvent.md
+++ b/eiffel-vocabulary/EiffelIssueDefinedEvent.md
@@ -204,7 +204,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
-| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12 and add link validation. |
 | 3.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |

--- a/eiffel-vocabulary/EiffelIssueVerifiedEvent.md
+++ b/eiffel-vocabulary/EiffelIssueVerifiedEvent.md
@@ -204,7 +204,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
-| 5.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
+| 5.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12 and add link validation. |
 | 4.3.1 | Not yet released in an edition | Change IUT to Implementation Under Test (see [Issue 235](https://github.com/eiffel-community/eiffel/issues/359)). |
 | 4.3.0 | [edition-orizaba](../../../tree/edition-orizaba) | Add artifact deployed event as legal IUT target (see [Issue 239](https://github.com/eiffel-community/eiffel/issues/239)). |
 | 4.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |

--- a/eiffel-vocabulary/EiffelIssueVerifiedEvent.md
+++ b/eiffel-vocabulary/EiffelIssueVerifiedEvent.md
@@ -1,5 +1,5 @@
 <!---
-   This file was generated from ../definitions/EiffelIssueVerifiedEvent/4.3.1.yml.
+   This file was generated from ../definitions/EiffelIssueVerifiedEvent/5.0.0.yml.
    See that file for a copyright notice.
 --->
 
@@ -204,6 +204,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
+| 5.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
 | 4.3.1 | Not yet released in an edition | Change IUT to Implementation Under Test (see [Issue 235](https://github.com/eiffel-community/eiffel/issues/359)). |
 | 4.3.0 | [edition-orizaba](../../../tree/edition-orizaba) | Add artifact deployed event as legal IUT target (see [Issue 239](https://github.com/eiffel-community/eiffel/issues/239)). |
 | 4.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |

--- a/eiffel-vocabulary/EiffelSourceChangeCreatedEvent.md
+++ b/eiffel-vocabulary/EiffelSourceChangeCreatedEvent.md
@@ -353,7 +353,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
-| 5.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
+| 5.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12 and add link validation. |
 | 4.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 4.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 4.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |

--- a/eiffel-vocabulary/EiffelSourceChangeCreatedEvent.md
+++ b/eiffel-vocabulary/EiffelSourceChangeCreatedEvent.md
@@ -1,5 +1,5 @@
 <!---
-   This file was generated from ../definitions/EiffelSourceChangeCreatedEvent/4.2.0.yml.
+   This file was generated from ../definitions/EiffelSourceChangeCreatedEvent/5.0.0.yml.
    See that file for a copyright notice.
 --->
 
@@ -353,6 +353,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
+| 5.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
 | 4.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 4.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 4.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |

--- a/eiffel-vocabulary/EiffelSourceChangeSubmittedEvent.md
+++ b/eiffel-vocabulary/EiffelSourceChangeSubmittedEvent.md
@@ -1,5 +1,5 @@
 <!---
-   This file was generated from ../definitions/EiffelSourceChangeSubmittedEvent/3.2.0.yml.
+   This file was generated from ../definitions/EiffelSourceChangeSubmittedEvent/4.0.0.yml.
    See that file for a copyright notice.
 --->
 
@@ -302,6 +302,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
 | 3.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |

--- a/eiffel-vocabulary/EiffelSourceChangeSubmittedEvent.md
+++ b/eiffel-vocabulary/EiffelSourceChangeSubmittedEvent.md
@@ -302,7 +302,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
-| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12 and add link validation. |
 | 3.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |

--- a/eiffel-vocabulary/EiffelTestCaseCanceledEvent.md
+++ b/eiffel-vocabulary/EiffelTestCaseCanceledEvent.md
@@ -1,5 +1,5 @@
 <!---
-   This file was generated from ../definitions/EiffelTestCaseCanceledEvent/3.2.0.yml.
+   This file was generated from ../definitions/EiffelTestCaseCanceledEvent/4.0.0.yml.
    See that file for a copyright notice.
 --->
 
@@ -177,6 +177,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
 | 3.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |

--- a/eiffel-vocabulary/EiffelTestCaseCanceledEvent.md
+++ b/eiffel-vocabulary/EiffelTestCaseCanceledEvent.md
@@ -177,7 +177,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
-| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12 and add link validation. |
 | 3.2.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.0.0 | [edition-agen](../../../tree/edition-agen) | Improved information integrity protection (see [Issue 185](https://github.com/eiffel-community/eiffel/issues/185)). |

--- a/eiffel-vocabulary/EiffelTestCaseFinishedEvent.md
+++ b/eiffel-vocabulary/EiffelTestCaseFinishedEvent.md
@@ -1,5 +1,5 @@
 <!---
-   This file was generated from ../definitions/EiffelTestCaseFinishedEvent/3.3.1.yml.
+   This file was generated from ../definitions/EiffelTestCaseFinishedEvent/4.0.0.yml.
    See that file for a copyright notice.
 --->
 
@@ -246,6 +246,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
 | 3.3.1 | Not yet released in an edition | Change IUT to Implementation Under Test (see [Issue 235](https://github.com/eiffel-community/eiffel/issues/359)). |
 | 3.3.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.2.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |

--- a/eiffel-vocabulary/EiffelTestCaseFinishedEvent.md
+++ b/eiffel-vocabulary/EiffelTestCaseFinishedEvent.md
@@ -246,7 +246,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
-| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12 and add link validation. |
 | 3.3.1 | Not yet released in an edition | Change IUT to Implementation Under Test (see [Issue 235](https://github.com/eiffel-community/eiffel/issues/359)). |
 | 3.3.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.2.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |

--- a/eiffel-vocabulary/EiffelTestCaseStartedEvent.md
+++ b/eiffel-vocabulary/EiffelTestCaseStartedEvent.md
@@ -1,5 +1,5 @@
 <!---
-   This file was generated from ../definitions/EiffelTestCaseStartedEvent/3.3.0.yml.
+   This file was generated from ../definitions/EiffelTestCaseStartedEvent/4.0.0.yml.
    See that file for a copyright notice.
 --->
 
@@ -208,6 +208,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
 | 3.3.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.2.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add `data.liveLogs.{mediaType,tags}`. |

--- a/eiffel-vocabulary/EiffelTestCaseStartedEvent.md
+++ b/eiffel-vocabulary/EiffelTestCaseStartedEvent.md
@@ -208,7 +208,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
-| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12 and add link validation. |
 | 3.3.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.2.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |
 | 3.1.0 | [edition-lyon](../../../tree/edition-lyon) | Add `data.liveLogs.{mediaType,tags}`. |

--- a/eiffel-vocabulary/EiffelTestCaseTriggeredEvent.md
+++ b/eiffel-vocabulary/EiffelTestCaseTriggeredEvent.md
@@ -258,7 +258,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
-| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12 and add link validation. |
 | 3.5.1 | Not yet released in an edition | Change IUT to Implementation Under Test (see [Issue 235](https://github.com/eiffel-community/eiffel/issues/359)). |
 | 3.5.0 | [edition-orizaba](../../../tree/edition-orizaba) | Add ORIGINAL_TRIGGER link (see [Issue 246](https://github.com/eiffel-community/eiffel/issues/246)). |
 | 3.4.0 | [edition-orizaba](../../../tree/edition-orizaba) | Add artifact deployed event as legal IUT target (see [Issue 239](https://github.com/eiffel-community/eiffel/issues/239)). |

--- a/eiffel-vocabulary/EiffelTestCaseTriggeredEvent.md
+++ b/eiffel-vocabulary/EiffelTestCaseTriggeredEvent.md
@@ -1,5 +1,5 @@
 <!---
-   This file was generated from ../definitions/EiffelTestCaseTriggeredEvent/3.5.1.yml.
+   This file was generated from ../definitions/EiffelTestCaseTriggeredEvent/4.0.0.yml.
    See that file for a copyright notice.
 --->
 
@@ -258,6 +258,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
 | 3.5.1 | Not yet released in an edition | Change IUT to Implementation Under Test (see [Issue 235](https://github.com/eiffel-community/eiffel/issues/359)). |
 | 3.5.0 | [edition-orizaba](../../../tree/edition-orizaba) | Add ORIGINAL_TRIGGER link (see [Issue 246](https://github.com/eiffel-community/eiffel/issues/246)). |
 | 3.4.0 | [edition-orizaba](../../../tree/edition-orizaba) | Add artifact deployed event as legal IUT target (see [Issue 239](https://github.com/eiffel-community/eiffel/issues/239)). |

--- a/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md
+++ b/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md
@@ -1,5 +1,5 @@
 <!---
-   This file was generated from ../definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.3.1.yml.
+   This file was generated from ../definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/5.0.0.yml.
    See that file for a copyright notice.
 --->
 
@@ -279,6 +279,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
+| 5.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
 | 4.3.1 | Not yet released in an edition | Change IUT to Implementation Under Test (see [Issue 235](https://github.com/eiffel-community/eiffel/issues/359)). |
 | 4.3.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 4.2.0 | [edition-arica](../../../tree/edition-arica) | Add missing testCase.version member (see [Issue 288](https://github.com/eiffel-community/eiffel/issues/288)). |

--- a/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md
+++ b/eiffel-vocabulary/EiffelTestExecutionRecipeCollectionCreatedEvent.md
@@ -279,7 +279,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
-| 5.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
+| 5.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12 and add link validation. |
 | 4.3.1 | Not yet released in an edition | Change IUT to Implementation Under Test (see [Issue 235](https://github.com/eiffel-community/eiffel/issues/359)). |
 | 4.3.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 4.2.0 | [edition-arica](../../../tree/edition-arica) | Add missing testCase.version member (see [Issue 288](https://github.com/eiffel-community/eiffel/issues/288)). |

--- a/eiffel-vocabulary/EiffelTestSuiteFinishedEvent.md
+++ b/eiffel-vocabulary/EiffelTestSuiteFinishedEvent.md
@@ -229,7 +229,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
-| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12 and add link validation. |
 | 3.3.1 | Not yet released in an edition | Change IUT to Implementation Under Test (see [Issue 235](https://github.com/eiffel-community/eiffel/issues/359)). |
 | 3.3.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.2.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |

--- a/eiffel-vocabulary/EiffelTestSuiteFinishedEvent.md
+++ b/eiffel-vocabulary/EiffelTestSuiteFinishedEvent.md
@@ -1,5 +1,5 @@
 <!---
-   This file was generated from ../definitions/EiffelTestSuiteFinishedEvent/3.3.1.yml.
+   This file was generated from ../definitions/EiffelTestSuiteFinishedEvent/4.0.0.yml.
    See that file for a copyright notice.
 --->
 
@@ -229,6 +229,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
 | 3.3.1 | Not yet released in an edition | Change IUT to Implementation Under Test (see [Issue 235](https://github.com/eiffel-community/eiffel/issues/359)). |
 | 3.3.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.2.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |

--- a/eiffel-vocabulary/EiffelTestSuiteStartedEvent.md
+++ b/eiffel-vocabulary/EiffelTestSuiteStartedEvent.md
@@ -1,5 +1,5 @@
 <!---
-   This file was generated from ../definitions/EiffelTestSuiteStartedEvent/3.4.0.yml.
+   This file was generated from ../definitions/EiffelTestSuiteStartedEvent/4.0.0.yml.
    See that file for a copyright notice.
 --->
 
@@ -227,6 +227,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
 | 3.4.0 | [edition-orizaba](../../../tree/edition-orizaba) | Add ORIGINAL_TRIGGER link (see [Issue 246](https://github.com/eiffel-community/eiffel/issues/246)). |
 | 3.3.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.2.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |

--- a/eiffel-vocabulary/EiffelTestSuiteStartedEvent.md
+++ b/eiffel-vocabulary/EiffelTestSuiteStartedEvent.md
@@ -227,7 +227,7 @@ __Description:__ A URI pointing at a location from where the schema used when cr
 
 | Version | Introduced in | Changes |
 | ------- | ------------- | ------- |
-| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12. |
+| 4.0.0 | Not yet released in an edition | Update meta schema to Draft 2020-12 and add link validation. |
 | 3.4.0 | [edition-orizaba](../../../tree/edition-orizaba) | Add ORIGINAL_TRIGGER link (see [Issue 246](https://github.com/eiffel-community/eiffel/issues/246)). |
 | 3.3.0 | [edition-arica](../../../tree/edition-arica) | Add schema URL to the meta object (see [Issue 280](https://github.com/eiffel-community/eiffel/issues/280)). |
 | 3.2.0 | [edition-lyon](../../../tree/edition-lyon) | Add links.domainId member (see [Issue 233](https://github.com/eiffel-community/eiffel/issues/233)). |

--- a/examples/events/EiffelActivityCanceledEvent/simple.json
+++ b/examples/events/EiffelActivityCanceledEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelActivityCanceledEvent",
-    "version": "3.0.0",
+    "version": "5.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },

--- a/examples/events/EiffelActivityFinishedEvent/simple.json
+++ b/examples/events/EiffelActivityFinishedEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelActivityFinishedEvent",
-    "version": "3.1.0",
+    "version": "4.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },

--- a/examples/events/EiffelActivityStartedEvent/simple.json
+++ b/examples/events/EiffelActivityStartedEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelActivityStartedEvent",
-    "version": "4.1.0",
+    "version": "5.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },

--- a/examples/events/EiffelActivityTriggeredEvent/simple-customdata.json
+++ b/examples/events/EiffelActivityTriggeredEvent/simple-customdata.json
@@ -2,7 +2,7 @@
   "meta": {
     "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0",
     "type": "EiffelActivityTriggeredEvent",
-    "version": "3.0.0",
+    "version": "5.0.0",
     "time": 1234567890,
     "source": {
       "domainId": "test-domainId"

--- a/examples/events/EiffelActivityTriggeredEvent/simple.json
+++ b/examples/events/EiffelActivityTriggeredEvent/simple.json
@@ -2,7 +2,7 @@
   "meta": {
     "id": "e1e93f13-7c3c-4f17-9753-ebf0c86ff1c2",
     "type": "EiffelActivityTriggeredEvent",
-    "version": "3.0.0",
+    "version": "5.0.0",
     "time": 1234567890
   },
   "data": {

--- a/examples/events/EiffelAnnouncementPublishedEvent/simple.json
+++ b/examples/events/EiffelAnnouncementPublishedEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelAnnouncementPublishedEvent",
-    "version": "3.0.0",
+    "version": "4.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },

--- a/examples/events/EiffelArtifactCreatedEvent/backend.json
+++ b/examples/events/EiffelArtifactCreatedEvent/backend.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelArtifactCreatedEvent",
-    "version": "3.0.0",
+    "version": "4.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },

--- a/examples/events/EiffelArtifactCreatedEvent/checksum.json
+++ b/examples/events/EiffelArtifactCreatedEvent/checksum.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelArtifactCreatedEvent",
-    "version": "3.3.0",
+    "version": "4.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },

--- a/examples/events/EiffelArtifactCreatedEvent/dependent.json
+++ b/examples/events/EiffelArtifactCreatedEvent/dependent.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelArtifactCreatedEvent",
-    "version": "3.0.0",
+    "version": "4.0.0",
     "time": 1234567890,
     "source": {
       "uri": "https://ci.internal.myorg.org/ArtifactBuilder/info"

--- a/examples/events/EiffelArtifactCreatedEvent/interface.json
+++ b/examples/events/EiffelArtifactCreatedEvent/interface.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelArtifactCreatedEvent",
-    "version": "3.0.0",
+    "version": "4.0.0",
     "time": 1234567890,
     "source": {
       "serializer": "pkg:maven/com.mycompany.pipeline-tools/eiffel-serializer@57"

--- a/examples/events/EiffelArtifactCreatedEvent/simple.json
+++ b/examples/events/EiffelArtifactCreatedEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelArtifactCreatedEvent",
-    "version": "3.0.0",
+    "version": "4.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0",
     "source": {

--- a/examples/events/EiffelArtifactDeployedEvent/simple.json
+++ b/examples/events/EiffelArtifactDeployedEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelArtifactDeployedEvent",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0",
     "source": {

--- a/examples/events/EiffelArtifactPublishedEvent/multifile.json
+++ b/examples/events/EiffelArtifactPublishedEvent/multifile.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelArtifactPublishedEvent",
-    "version": "3.1.0",
+    "version": "4.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },

--- a/examples/events/EiffelArtifactPublishedEvent/simple.json
+++ b/examples/events/EiffelArtifactPublishedEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelArtifactPublishedEvent",
-    "version": "3.0.0",
+    "version": "4.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0",
     "security": {

--- a/examples/events/EiffelArtifactReusedEvent/simple.json
+++ b/examples/events/EiffelArtifactReusedEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelArtifactReusedEvent",
-    "version": "3.0.0",
+    "version": "4.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0",
     "source": {

--- a/examples/events/EiffelCompositionDefinedEvent/simple.json
+++ b/examples/events/EiffelCompositionDefinedEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelCompositionDefinedEvent",
-    "version": "3.0.0",
+    "version": "4.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },

--- a/examples/events/EiffelConfidenceLevelModifiedEvent/simple.json
+++ b/examples/events/EiffelConfidenceLevelModifiedEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelConfidenceLevelModifiedEvent",
-    "version": "3.0.0",
+    "version": "4.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },

--- a/examples/events/EiffelEnvironmentDefinedEvent/host.json
+++ b/examples/events/EiffelEnvironmentDefinedEvent/host.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelEnvironmentDefinedEvent",
-    "version": "3.0.0",
+    "version": "4.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0",
     "source": {

--- a/examples/events/EiffelEnvironmentDefinedEvent/image.json
+++ b/examples/events/EiffelEnvironmentDefinedEvent/image.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelEnvironmentDefinedEvent",
-    "version": "3.0.0",
+    "version": "4.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },

--- a/examples/events/EiffelEnvironmentDefinedEvent/runtime-env-link.json
+++ b/examples/events/EiffelEnvironmentDefinedEvent/runtime-env-link.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelEnvironmentDefinedEvent",
-    "version": "3.1.0",
+    "version": "4.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0",
     "source": {

--- a/examples/events/EiffelEnvironmentDefinedEvent/uri.json
+++ b/examples/events/EiffelEnvironmentDefinedEvent/uri.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelEnvironmentDefinedEvent",
-    "version": "3.0.0",
+    "version": "4.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0",
     "source": {

--- a/examples/events/EiffelFlowContextDefinedEvent/simple.json
+++ b/examples/events/EiffelFlowContextDefinedEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelFlowContextDefinedEvent",
-    "version": "3.0.0",
+    "version": "4.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },

--- a/examples/events/EiffelIssueDefinedEvent/simple.json
+++ b/examples/events/EiffelIssueDefinedEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelIssueDefinedEvent",
-    "version": "3.0.0",
+    "version": "4.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },

--- a/examples/events/EiffelIssueVerifiedEvent/simple.json
+++ b/examples/events/EiffelIssueVerifiedEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelIssueVerifiedEvent",
-    "version": "4.0.0",
+    "version": "5.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },

--- a/examples/events/EiffelSourceChangeCreatedEvent/simple.json
+++ b/examples/events/EiffelSourceChangeCreatedEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelSourceChangeCreatedEvent",
-    "version": "4.0.0",
+    "version": "5.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },

--- a/examples/events/EiffelSourceChangeSubmittedEvent/simple.json
+++ b/examples/events/EiffelSourceChangeSubmittedEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelSourceChangeSubmittedEvent",
-    "version": "3.0.0",
+    "version": "4.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },

--- a/examples/events/EiffelTestCaseCanceledEvent/simple.json
+++ b/examples/events/EiffelTestCaseCanceledEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelTestCaseCanceledEvent",
-    "version": "3.0.0",
+    "version": "4.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },

--- a/examples/events/EiffelTestCaseFinishedEvent/simple.json
+++ b/examples/events/EiffelTestCaseFinishedEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelTestCaseFinishedEvent",
-    "version": "3.1.0",
+    "version": "4.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },

--- a/examples/events/EiffelTestCaseStartedEvent/simple.json
+++ b/examples/events/EiffelTestCaseStartedEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelTestCaseStartedEvent",
-    "version": "3.1.0",
+    "version": "4.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },

--- a/examples/events/EiffelTestCaseTriggeredEvent/simple.json
+++ b/examples/events/EiffelTestCaseTriggeredEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelTestCaseTriggeredEvent",
-    "version": "3.0.0",
+    "version": "4.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0",
     "security": {

--- a/examples/events/EiffelTestExecutionRecipeCollectionCreatedEvent/batches.json
+++ b/examples/events/EiffelTestExecutionRecipeCollectionCreatedEvent/batches.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelTestExecutionRecipeCollectionCreatedEvent",
-    "version": "4.0.0",
+    "version": "5.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },

--- a/examples/events/EiffelTestExecutionRecipeCollectionCreatedEvent/batchesUri.json
+++ b/examples/events/EiffelTestExecutionRecipeCollectionCreatedEvent/batchesUri.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelTestExecutionRecipeCollectionCreatedEvent",
-    "version": "4.0.0",
+    "version": "5.0.0",
     "time": 1234567890,
     "source": {
       "domainId": "example.domain"

--- a/examples/events/EiffelTestSuiteFinishedEvent/simple.json
+++ b/examples/events/EiffelTestSuiteFinishedEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelTestSuiteFinishedEvent",
-    "version": "3.1.0",
+    "version": "4.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },

--- a/examples/events/EiffelTestSuiteStartedEvent/simple.json
+++ b/examples/events/EiffelTestSuiteStartedEvent/simple.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "type": "EiffelTestSuiteStartedEvent",
-    "version": "3.1.0",
+    "version": "4.0.0",
     "time": 1234567890,
     "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
   },

--- a/schemas/EiffelActivityCanceledEvent/5.0.0.json
+++ b/schemas/EiffelActivityCanceledEvent/5.0.0.json
@@ -1,0 +1,198 @@
+{
+  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelActivityCanceledEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "5.0.0"
+          ],
+          "default": "5.0.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "reason": {
+          "type": "string"
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "contains": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "enum": [
+              "ACTIVITY_EXECUTION"
+            ]
+          }
+        }
+      },
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/EiffelActivityCanceledEvent/5.0.0.json
+++ b/schemas/EiffelActivityCanceledEvent/5.0.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
   "type": "object",
   "properties": {
     "meta": {

--- a/schemas/EiffelActivityFinishedEvent/4.0.0.json
+++ b/schemas/EiffelActivityFinishedEvent/4.0.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
   "type": "object",
   "properties": {
     "meta": {

--- a/schemas/EiffelActivityFinishedEvent/4.0.0.json
+++ b/schemas/EiffelActivityFinishedEvent/4.0.0.json
@@ -1,0 +1,248 @@
+{
+  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelActivityFinishedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "4.0.0"
+          ],
+          "default": "4.0.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "outcome": {
+          "type": "object",
+          "properties": {
+            "conclusion": {
+              "type": "string",
+              "enum": [
+                "SUCCESSFUL",
+                "UNSUCCESSFUL",
+                "FAILED",
+                "ABORTED",
+                "TIMED_OUT",
+                "INCONCLUSIVE"
+              ]
+            },
+            "description": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "conclusion"
+          ]
+        },
+        "persistentLogs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "mediaType": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "uri": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "uri"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "outcome"
+      ]
+    },
+    "links": {
+      "type": "array",
+      "contains": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "enum": [
+              "ACTIVITY_EXECUTION"
+            ]
+          }
+        }
+      },
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/EiffelActivityStartedEvent/5.0.0.json
+++ b/schemas/EiffelActivityStartedEvent/5.0.0.json
@@ -1,0 +1,226 @@
+{
+  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelActivityStartedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "5.0.0"
+          ],
+          "default": "5.0.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "executionUri": {
+          "type": "string"
+        },
+        "liveLogs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "mediaType": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "uri": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "uri"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "contains": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "enum": [
+              "ACTIVITY_EXECUTION"
+            ]
+          }
+        }
+      },
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/EiffelActivityStartedEvent/5.0.0.json
+++ b/schemas/EiffelActivityStartedEvent/5.0.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
   "type": "object",
   "properties": {
     "meta": {

--- a/schemas/EiffelActivityTriggeredEvent/5.0.0.json
+++ b/schemas/EiffelActivityTriggeredEvent/5.0.0.json
@@ -1,0 +1,231 @@
+{
+  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelActivityTriggeredEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "5.0.0"
+          ],
+          "default": "5.0.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "triggers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "MANUAL",
+                  "EIFFEL_EVENT",
+                  "SOURCE_CHANGE",
+                  "TIMER",
+                  "OTHER"
+                ]
+              },
+              "description": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "executionType": {
+          "type": "string",
+          "enum": [
+            "MANUAL",
+            "SEMI_AUTOMATED",
+            "AUTOMATED",
+            "OTHER"
+          ]
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/EiffelActivityTriggeredEvent/5.0.0.json
+++ b/schemas/EiffelActivityTriggeredEvent/5.0.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
   "type": "object",
   "properties": {
     "meta": {

--- a/schemas/EiffelAnnouncementPublishedEvent/4.0.0.json
+++ b/schemas/EiffelAnnouncementPublishedEvent/4.0.0.json
@@ -1,0 +1,210 @@
+{
+  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelAnnouncementPublishedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "4.0.0"
+          ],
+          "default": "4.0.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "heading": {
+          "type": "string"
+        },
+        "body": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "severity": {
+          "type": "string",
+          "enum": [
+            "MINOR",
+            "MAJOR",
+            "CRITICAL",
+            "BLOCKER",
+            "CLOSED",
+            "CANCELED"
+          ]
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "heading",
+        "body",
+        "severity"
+      ],
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/EiffelAnnouncementPublishedEvent/4.0.0.json
+++ b/schemas/EiffelAnnouncementPublishedEvent/4.0.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
   "type": "object",
   "properties": {
     "meta": {

--- a/schemas/EiffelArtifactCreatedEvent/4.0.0.json
+++ b/schemas/EiffelArtifactCreatedEvent/4.0.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
   "type": "object",
   "properties": {
     "meta": {

--- a/schemas/EiffelArtifactCreatedEvent/4.0.0.json
+++ b/schemas/EiffelArtifactCreatedEvent/4.0.0.json
@@ -1,0 +1,267 @@
+{
+  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelArtifactCreatedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "4.0.0"
+          ],
+          "default": "4.0.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "identity": {
+          "type": "string",
+          "pattern": "^pkg:"
+        },
+        "fileInformation": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "integrityProtection": {
+                "type": "object",
+                "properties": {
+                  "alg": {
+                    "type": "string",
+                    "enum": [
+                      "SHA-224",
+                      "SHA-256",
+                      "SHA-384",
+                      "SHA-512",
+                      "SHA-512/224",
+                      "SHA-512/256"
+                    ]
+                  },
+                  "digest": {
+                    "type": "string",
+                    "pattern": "^[0-9a-f]+$"
+                  }
+                },
+                "required": [
+                  "alg",
+                  "digest"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "buildCommand": {
+          "type": "string"
+        },
+        "requiresImplementation": {
+          "type": "string",
+          "enum": [
+            "NONE",
+            "ANY",
+            "EXACTLY_ONE",
+            "AT_LEAST_ONE"
+          ]
+        },
+        "dependsOn": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^pkg:"
+          }
+        },
+        "implements": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^pkg:"
+          }
+        },
+        "name": {
+          "type": "string"
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "identity"
+      ],
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/EiffelArtifactDeployedEvent/0.2.0.json
+++ b/schemas/EiffelArtifactDeployedEvent/0.2.0.json
@@ -1,0 +1,202 @@
+{
+  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelArtifactDeployedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "0.2.0"
+          ],
+          "default": "0.2.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "contains": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "enum": [
+              "ARTIFACT",
+              "ENVIRONMENT"
+            ]
+          }
+        }
+      },
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/EiffelArtifactDeployedEvent/0.2.0.json
+++ b/schemas/EiffelArtifactDeployedEvent/0.2.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
   "type": "object",
   "properties": {
     "meta": {

--- a/schemas/EiffelArtifactPublishedEvent/4.0.0.json
+++ b/schemas/EiffelArtifactPublishedEvent/4.0.0.json
@@ -1,0 +1,226 @@
+{
+  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelArtifactPublishedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "4.0.0"
+          ],
+          "default": "4.0.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "locations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ARTIFACTORY",
+                  "NEXUS",
+                  "PLAIN",
+                  "OTHER"
+                ]
+              },
+              "uri": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "uri"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "locations"
+      ],
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "contains": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "enum": [
+              "ARTIFACT"
+            ]
+          }
+        }
+      },
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/EiffelArtifactPublishedEvent/4.0.0.json
+++ b/schemas/EiffelArtifactPublishedEvent/4.0.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
   "type": "object",
   "properties": {
     "meta": {

--- a/schemas/EiffelArtifactReusedEvent/4.0.0.json
+++ b/schemas/EiffelArtifactReusedEvent/4.0.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
   "type": "object",
   "properties": {
     "meta": {

--- a/schemas/EiffelArtifactReusedEvent/4.0.0.json
+++ b/schemas/EiffelArtifactReusedEvent/4.0.0.json
@@ -1,0 +1,196 @@
+{
+  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelArtifactReusedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "4.0.0"
+          ],
+          "default": "4.0.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "contains": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "enum": [
+              "COMPOSITION",
+              "REUSED_ARTIFACT"
+            ]
+          }
+        }
+      },
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/EiffelCompositionDefinedEvent/4.0.0.json
+++ b/schemas/EiffelCompositionDefinedEvent/4.0.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
   "type": "object",
   "properties": {
     "meta": {

--- a/schemas/EiffelCompositionDefinedEvent/4.0.0.json
+++ b/schemas/EiffelCompositionDefinedEvent/4.0.0.json
@@ -1,0 +1,194 @@
+{
+  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelCompositionDefinedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "4.0.0"
+          ],
+          "default": "4.0.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/EiffelConfidenceLevelModifiedEvent/4.0.0.json
+++ b/schemas/EiffelConfidenceLevelModifiedEvent/4.0.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
   "type": "object",
   "properties": {
     "meta": {

--- a/schemas/EiffelConfidenceLevelModifiedEvent/4.0.0.json
+++ b/schemas/EiffelConfidenceLevelModifiedEvent/4.0.0.json
@@ -1,0 +1,228 @@
+{
+  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelConfidenceLevelModifiedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "4.0.0"
+          ],
+          "default": "4.0.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string",
+          "enum": [
+            "SUCCESS",
+            "FAILURE",
+            "INCONCLUSIVE"
+          ]
+        },
+        "issuer": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "email": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "group": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ],
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "contains": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "enum": [
+              "SUBJECT"
+            ]
+          }
+        }
+      },
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/EiffelEnvironmentDefinedEvent/4.0.0.json
+++ b/schemas/EiffelEnvironmentDefinedEvent/4.0.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
   "type": "object",
   "properties": {
     "meta": {

--- a/schemas/EiffelEnvironmentDefinedEvent/4.0.0.json
+++ b/schemas/EiffelEnvironmentDefinedEvent/4.0.0.json
@@ -1,0 +1,216 @@
+{
+  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelEnvironmentDefinedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "4.0.0"
+          ],
+          "default": "4.0.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "image": {
+          "type": "string"
+        },
+        "host": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "user": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "user"
+          ],
+          "additionalProperties": false
+        },
+        "uri": {
+          "type": "string"
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/EiffelFlowContextDefinedEvent/4.0.0.json
+++ b/schemas/EiffelFlowContextDefinedEvent/4.0.0.json
@@ -1,0 +1,200 @@
+{
+  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelFlowContextDefinedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "4.0.0"
+          ],
+          "default": "4.0.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "product": {
+          "type": "string"
+        },
+        "project": {
+          "type": "string"
+        },
+        "program": {
+          "type": "string"
+        },
+        "track": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/EiffelFlowContextDefinedEvent/4.0.0.json
+++ b/schemas/EiffelFlowContextDefinedEvent/4.0.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
   "type": "object",
   "properties": {
     "meta": {

--- a/schemas/EiffelIssueDefinedEvent/4.0.0.json
+++ b/schemas/EiffelIssueDefinedEvent/4.0.0.json
@@ -1,0 +1,208 @@
+{
+  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelIssueDefinedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "4.0.0"
+          ],
+          "default": "4.0.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "BUG",
+            "IMPROVEMENT",
+            "FEATURE",
+            "WORK_ITEM",
+            "REQUIREMENT",
+            "OTHER"
+          ]
+        },
+        "tracker": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "type",
+        "tracker",
+        "id",
+        "uri"
+      ],
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  }
+}

--- a/schemas/EiffelIssueDefinedEvent/4.0.0.json
+++ b/schemas/EiffelIssueDefinedEvent/4.0.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
   "type": "object",
   "properties": {
     "meta": {

--- a/schemas/EiffelIssueVerifiedEvent/5.0.0.json
+++ b/schemas/EiffelIssueVerifiedEvent/5.0.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
   "type": "object",
   "properties": {
     "meta": {

--- a/schemas/EiffelIssueVerifiedEvent/5.0.0.json
+++ b/schemas/EiffelIssueVerifiedEvent/5.0.0.json
@@ -1,0 +1,195 @@
+{
+  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelIssueVerifiedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "5.0.0"
+          ],
+          "default": "5.0.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "contains": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "enum": [
+              "IUT"
+            ]
+          }
+        }
+      },
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/EiffelSourceChangeCreatedEvent/5.0.0.json
+++ b/schemas/EiffelSourceChangeCreatedEvent/5.0.0.json
@@ -1,0 +1,317 @@
+{
+  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelSourceChangeCreatedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "5.0.0"
+          ],
+          "default": "5.0.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "author": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "email": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "group": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "change": {
+          "type": "object",
+          "properties": {
+            "insertions": {
+              "type": "integer"
+            },
+            "deletions": {
+              "type": "integer"
+            },
+            "files": {
+              "type": "string"
+            },
+            "details": {
+              "type": "string"
+            },
+            "tracker": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "gitIdentifier": {
+          "type": "object",
+          "properties": {
+            "commitId": {
+              "type": "string"
+            },
+            "branch": {
+              "type": "string"
+            },
+            "repoName": {
+              "type": "string"
+            },
+            "repoUri": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "commitId",
+            "repoUri"
+          ],
+          "additionalProperties": false
+        },
+        "svnIdentifier": {
+          "type": "object",
+          "properties": {
+            "revision": {
+              "type": "integer"
+            },
+            "directory": {
+              "type": "string"
+            },
+            "repoName": {
+              "type": "string"
+            },
+            "repoUri": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "revision",
+            "directory",
+            "repoUri"
+          ],
+          "additionalProperties": false
+        },
+        "ccCompositeIdentifier": {
+          "type": "object",
+          "properties": {
+            "vobs": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "branch": {
+              "type": "string"
+            },
+            "configSpec": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "vobs",
+            "branch",
+            "configSpec"
+          ],
+          "additionalProperties": false
+        },
+        "hgIdentifier": {
+          "type": "object",
+          "properties": {
+            "commitId": {
+              "type": "string"
+            },
+            "branch": {
+              "type": "string"
+            },
+            "repoName": {
+              "type": "string"
+            },
+            "repoUri": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "commitId",
+            "repoUri"
+          ],
+          "additionalProperties": false
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/EiffelSourceChangeCreatedEvent/5.0.0.json
+++ b/schemas/EiffelSourceChangeCreatedEvent/5.0.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
   "type": "object",
   "properties": {
     "meta": {

--- a/schemas/EiffelSourceChangeSubmittedEvent/4.0.0.json
+++ b/schemas/EiffelSourceChangeSubmittedEvent/4.0.0.json
@@ -1,0 +1,293 @@
+{
+  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelSourceChangeSubmittedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "4.0.0"
+          ],
+          "default": "4.0.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "submitter": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "email": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "group": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "gitIdentifier": {
+          "type": "object",
+          "properties": {
+            "commitId": {
+              "type": "string"
+            },
+            "branch": {
+              "type": "string"
+            },
+            "repoName": {
+              "type": "string"
+            },
+            "repoUri": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "commitId",
+            "repoUri"
+          ],
+          "additionalProperties": false
+        },
+        "svnIdentifier": {
+          "type": "object",
+          "properties": {
+            "revision": {
+              "type": "integer"
+            },
+            "directory": {
+              "type": "string"
+            },
+            "repoName": {
+              "type": "string"
+            },
+            "repoUri": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "revision",
+            "directory",
+            "repoUri"
+          ],
+          "additionalProperties": false
+        },
+        "ccCompositeIdentifier": {
+          "type": "object",
+          "properties": {
+            "vobs": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "branch": {
+              "type": "string"
+            },
+            "configSpec": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "vobs",
+            "branch",
+            "configSpec"
+          ],
+          "additionalProperties": false
+        },
+        "hgIdentifier": {
+          "type": "object",
+          "properties": {
+            "commitId": {
+              "type": "string"
+            },
+            "branch": {
+              "type": "string"
+            },
+            "repoName": {
+              "type": "string"
+            },
+            "repoUri": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "commitId",
+            "repoUri"
+          ],
+          "additionalProperties": false
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/EiffelSourceChangeSubmittedEvent/4.0.0.json
+++ b/schemas/EiffelSourceChangeSubmittedEvent/4.0.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
   "type": "object",
   "properties": {
     "meta": {

--- a/schemas/EiffelTestCaseCanceledEvent/4.0.0.json
+++ b/schemas/EiffelTestCaseCanceledEvent/4.0.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
   "type": "object",
   "properties": {
     "meta": {

--- a/schemas/EiffelTestCaseCanceledEvent/4.0.0.json
+++ b/schemas/EiffelTestCaseCanceledEvent/4.0.0.json
@@ -1,0 +1,198 @@
+{
+  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelTestCaseCanceledEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "4.0.0"
+          ],
+          "default": "4.0.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "reason": {
+          "type": "string"
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "contains": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "enum": [
+              "TEST_CASE_EXECUTION"
+            ]
+          }
+        }
+      },
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/EiffelTestCaseFinishedEvent/4.0.0.json
+++ b/schemas/EiffelTestCaseFinishedEvent/4.0.0.json
@@ -1,0 +1,274 @@
+{
+  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelTestCaseFinishedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "4.0.0"
+          ],
+          "default": "4.0.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "outcome": {
+          "type": "object",
+          "properties": {
+            "verdict": {
+              "type": "string",
+              "enum": [
+                "PASSED",
+                "FAILED",
+                "INCONCLUSIVE"
+              ]
+            },
+            "conclusion": {
+              "type": "string",
+              "enum": [
+                "SUCCESSFUL",
+                "FAILED",
+                "ABORTED",
+                "TIMED_OUT",
+                "INCONCLUSIVE"
+              ]
+            },
+            "description": {
+              "type": "string"
+            },
+            "metrics": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "value": {}
+                },
+                "required": [
+                  "name",
+                  "value"
+                ],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": [
+            "verdict",
+            "conclusion"
+          ],
+          "additionalProperties": false
+        },
+        "persistentLogs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "mediaType": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "uri": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "uri"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "outcome"
+      ],
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "contains": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "enum": [
+              "TEST_CASE_EXECUTION"
+            ]
+          }
+        }
+      },
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/EiffelTestCaseFinishedEvent/4.0.0.json
+++ b/schemas/EiffelTestCaseFinishedEvent/4.0.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
   "type": "object",
   "properties": {
     "meta": {

--- a/schemas/EiffelTestCaseStartedEvent/4.0.0.json
+++ b/schemas/EiffelTestCaseStartedEvent/4.0.0.json
@@ -1,0 +1,226 @@
+{
+  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelTestCaseStartedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "4.0.0"
+          ],
+          "default": "4.0.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "executor": {
+          "type": "string"
+        },
+        "liveLogs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "mediaType": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "uri": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "uri"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "contains": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "enum": [
+              "TEST_CASE_EXECUTION"
+            ]
+          }
+        }
+      },
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/EiffelTestCaseStartedEvent/4.0.0.json
+++ b/schemas/EiffelTestCaseStartedEvent/4.0.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
   "type": "object",
   "properties": {
     "meta": {

--- a/schemas/EiffelTestCaseTriggeredEvent/4.0.0.json
+++ b/schemas/EiffelTestCaseTriggeredEvent/4.0.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
   "type": "object",
   "properties": {
     "meta": {

--- a/schemas/EiffelTestCaseTriggeredEvent/4.0.0.json
+++ b/schemas/EiffelTestCaseTriggeredEvent/4.0.0.json
@@ -1,0 +1,276 @@
+{
+  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelTestCaseTriggeredEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "4.0.0"
+          ],
+          "default": "4.0.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "testCase": {
+          "type": "object",
+          "properties": {
+            "tracker": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "additionalProperties": false
+        },
+        "recipeId": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "triggers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "MANUAL",
+                  "EIFFEL_EVENT",
+                  "SOURCE_CHANGE",
+                  "TIMER",
+                  "OTHER"
+                ]
+              },
+              "description": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "executionType": {
+          "type": "string",
+          "enum": [
+            "MANUAL",
+            "SEMI_AUTOMATED",
+            "AUTOMATED",
+            "OTHER"
+          ]
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "testCase"
+      ],
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "contains": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "enum": [
+              "IUT"
+            ]
+          }
+        }
+      },
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/EiffelTestExecutionRecipeCollectionCreatedEvent/5.0.0.json
+++ b/schemas/EiffelTestExecutionRecipeCollectionCreatedEvent/5.0.0.json
@@ -1,0 +1,302 @@
+{
+  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelTestExecutionRecipeCollectionCreatedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "5.0.0"
+          ],
+          "default": "5.0.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "selectionStrategy": {
+          "type": "object",
+          "properties": {
+            "tracker": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "additionalProperties": false
+        },
+        "batchesUri": {
+          "type": "string"
+        },
+        "batches": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "priority": {
+                "type": "integer"
+              },
+              "recipes": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+                    },
+                    "testCase": {
+                      "type": "object",
+                      "properties": {
+                        "tracker": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "version": {
+                          "type": "string"
+                        },
+                        "uri": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "constraints": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "value": {}
+                        },
+                        "required": [
+                          "key",
+                          "value"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "testCase"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "dependencies": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "dependent": {
+                      "type": "string"
+                    },
+                    "dependency": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "dependent",
+                    "dependency"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "priority",
+              "recipes"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "selectionStrategy"
+      ],
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/EiffelTestExecutionRecipeCollectionCreatedEvent/5.0.0.json
+++ b/schemas/EiffelTestExecutionRecipeCollectionCreatedEvent/5.0.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
   "type": "object",
   "properties": {
     "meta": {

--- a/schemas/EiffelTestSuiteFinishedEvent/4.0.0.json
+++ b/schemas/EiffelTestSuiteFinishedEvent/4.0.0.json
@@ -1,0 +1,250 @@
+{
+  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelTestSuiteFinishedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "4.0.0"
+          ],
+          "default": "4.0.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "outcome": {
+          "type": "object",
+          "properties": {
+            "verdict": {
+              "type": "string",
+              "enum": [
+                "PASSED",
+                "FAILED",
+                "INCONCLUSIVE"
+              ]
+            },
+            "conclusion": {
+              "type": "string",
+              "enum": [
+                "SUCCESSFUL",
+                "FAILED",
+                "ABORTED",
+                "TIMED_OUT",
+                "INCONCLUSIVE"
+              ]
+            },
+            "description": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "persistentLogs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "mediaType": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "uri": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "uri"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "contains": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "enum": [
+              "TEST_SUITE_EXECUTION"
+            ]
+          }
+        }
+      },
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/EiffelTestSuiteFinishedEvent/4.0.0.json
+++ b/schemas/EiffelTestSuiteFinishedEvent/4.0.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
   "type": "object",
   "properties": {
     "meta": {

--- a/schemas/EiffelTestSuiteStartedEvent/4.0.0.json
+++ b/schemas/EiffelTestSuiteStartedEvent/4.0.0.json
@@ -1,0 +1,250 @@
+{
+  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelTestSuiteStartedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "4.0.0"
+          ],
+          "default": "4.0.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "types": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ACCESSIBILITY",
+              "BACKUP_RECOVERY",
+              "COMPATIBILITY",
+              "CONVERSION",
+              "DISASTER_RECOVERY",
+              "FUNCTIONAL",
+              "INSTALLABILITY",
+              "INTEROPERABILITY",
+              "LOCALIZATION",
+              "MAINTAINABILITY",
+              "PERFORMANCE",
+              "PORTABILITY",
+              "PROCEDURE",
+              "RELIABILITY",
+              "SECURITY",
+              "STABILITY",
+              "USABILITY"
+            ]
+          }
+        },
+        "liveLogs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "mediaType": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "uri": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "uri"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/schemas/EiffelTestSuiteStartedEvent/4.0.0.json
+++ b/schemas/EiffelTestSuiteStartedEvent/4.0.0.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/draft-2020-12/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema#",
   "type": "object",
   "properties": {
     "meta": {

--- a/test_definitions.py
+++ b/test_definitions.py
@@ -38,6 +38,12 @@ EVENT_DEFINITIONS = [
     DefinitionFile(p) for p in DEFINITION_FILES if p.parent.name.endswith("Event")
 ]
 EVENT_DEFINITION_IDS = [d.id for d in EVENT_DEFINITIONS]
+EVENT_DEFINITIONS_W_LINKS_REQUIRED = [
+    d for d in EVENT_DEFINITIONS if "2020-12" in d.definition.get("$schema")
+]
+EVENT_DEFINITION_W_LINKS_REQUIRED_IDS = [
+    d.id for d in EVENT_DEFINITIONS_W_LINKS_REQUIRED
+]
 OTHER_DEFINITIONS = [
     DefinitionFile(p) for p in DEFINITION_FILES if not p.parent.name.endswith("Event")
 ]
@@ -110,27 +116,23 @@ def test_filename_matches_type_version_fields(definition_file):
 
 @pytest.mark.parametrize(
     "definition_file",
-    EVENT_DEFINITIONS,
-    ids=EVENT_DEFINITION_IDS,
+    EVENT_DEFINITIONS_W_LINKS_REQUIRED,
+    ids=EVENT_DEFINITION_W_LINKS_REQUIRED_IDS,
 )
 def test_links(definition_file, manifest):
-    # Checking for required link is only valid for event types with recent meta schemas
-    if "draft-04" in definition_file.definition.get("$schema"):
-        assert True
-    else:
-        contained_link_types = []
-        required_link_types = []
-        schema_links_contains = (
-            definition_file.definition.get("properties").get("links").get("contains")
-        )
-        if schema_links_contains:
-            contained_link_types = (
-                schema_links_contains.get("properties").get("type").get("enum")
-            )
-        links = definition_file.definition.get("_links", {})
-        for link in links:
-            if links[link]["required"]:
-                required_link_types.append(link)
-        assert (
-            contained_link_types == required_link_types
-        ), f"Required '{required_link_types}' and contained '{contained_link_types}' link types do not match"
+    linktypes_in_schema = set(
+        definition_file.definition.get("properties", {})
+        .get("links", {})
+        .get("contains", {})
+        .get("properties", {})
+        .get("type", {})
+        .get("enum", [])
+    )
+    linktypes_in_definition = {
+        link_type
+        for link_type, link_def in definition_file.definition.get("_links", {}).items()
+        if link_def.get("required", False)
+    }
+    assert (
+        linktypes_in_schema == linktypes_in_definition
+    ), f"Link types required by schema ({linktypes_in_schema}) don't match link types required by definition file ({linktypes_in_definition})"

--- a/test_definitions.py
+++ b/test_definitions.py
@@ -106,3 +106,31 @@ def test_filename_matches_type_version_fields(definition_file):
     # Do they match what's in the definition?
     assert type == definition_file.definition["_name"]
     assert version == definition_file.definition["_version"]
+
+
+@pytest.mark.parametrize(
+    "definition_file",
+    EVENT_DEFINITIONS,
+    ids=EVENT_DEFINITION_IDS,
+)
+def test_links(definition_file, manifest):
+    # Checking for required link is only valid for event types with recent meta schemas
+    if "draft-04" in definition_file.definition.get("$schema"):
+        assert True
+    else:
+        contained_link_types = []
+        required_link_types = []
+        schema_links_contains = (
+            definition_file.definition.get("properties").get("links").get("contains")
+        )
+        if schema_links_contains:
+            contained_link_types = (
+                schema_links_contains.get("properties").get("type").get("enum")
+            )
+        links = definition_file.definition.get("_links", {})
+        for link in links:
+            if links[link]["required"]:
+                required_link_types.append(link)
+        assert (
+            contained_link_types == required_link_types
+        ), f"Required '{required_link_types}' and contained '{contained_link_types}' link types do not match"

--- a/test_jsonschema.py
+++ b/test_jsonschema.py
@@ -38,12 +38,41 @@ def test_json_schema(filename):
         in ["1.0.0", "1.1.0", "2.0.0", "3.0.0", "3.1.0", "3.2.0"]
     ):
         schema_validator = jsonschema.Draft4Validator
-    else:
+    elif "draft-04" in event_schema["$schema"]:
         stricter_metaschema = dict(
             jsonschema.Draft4Validator.META_SCHEMA, additionalProperties=False
         )
         schema_validator = jsonschema.validators.create(
             stricter_metaschema, jsonschema.Draft4Validator.VALIDATORS, "StrictDraft4"
         )
+    elif "draft-07" in event_schema["$schema"]:
+        # Kept even if not used, if a revert to this schema version is coming
+        stricter_metaschema = dict(
+            jsonschema.Draft7Validator.META_SCHEMA, additionalProperties=False
+        )
+        schema_validator = jsonschema.validators.create(
+            stricter_metaschema, jsonschema.Draft7Validator.VALIDATORS, "StrictDraft7"
+        )
+    elif "draft-2019-09" in event_schema["$schema"]:
+        # Kept even if not used, if a revert to this schema version is coming
+        stricter_metaschema = dict(
+            jsonschema.Draft201909Validator.META_SCHEMA, unevaluatedProperties=False
+        )
+        schema_validator = jsonschema.validators.create(
+            stricter_metaschema,
+            jsonschema.Draft201909Validator.VALIDATORS,
+            "StrictDraft201909",
+        )
+    elif "draft-2020-12" in event_schema["$schema"]:
+        stricter_metaschema = dict(
+            jsonschema.Draft202012Validator.META_SCHEMA, unevaluatedProperties=False
+        )
+        schema_validator = jsonschema.validators.create(
+            stricter_metaschema,
+            jsonschema.Draft202012Validator.VALIDATORS,
+            "StrictDraft202012",
+        )
+    else:
+        assert False
 
     schema_validator.check_schema(event_schema)

--- a/test_jsonschema.py
+++ b/test_jsonschema.py
@@ -53,7 +53,7 @@ def test_json_schema(filename):
         schema_validator = jsonschema.validators.create(
             stricter_metaschema, jsonschema.Draft7Validator.VALIDATORS, "StrictDraft7"
         )
-    elif "draft-2019-09" in event_schema["$schema"]:
+    elif "2019-09" in event_schema["$schema"]:
         # Kept even if not used, if a revert to this schema version is coming
         stricter_metaschema = dict(
             jsonschema.Draft201909Validator.META_SCHEMA, unevaluatedProperties=False
@@ -63,7 +63,7 @@ def test_json_schema(filename):
             jsonschema.Draft201909Validator.VALIDATORS,
             "StrictDraft201909",
         )
-    elif "draft-2020-12" in event_schema["$schema"]:
+    elif "2020-12" in event_schema["$schema"]:
         stricter_metaschema = dict(
             jsonschema.Draft202012Validator.META_SCHEMA, unevaluatedProperties=False
         )


### PR DESCRIPTION
### Applicable Issues
#148 

### Description of the Change

- Lift the JSON schema version to Draft 2020-12
- Declare required link types in schemas, to make validations more failsafe and simple
- Step major version of all event and object schemas, except for ArtD that is still below 1.0 and therefore cannot be raised to 1.0 in this PR.

### Alternate Designs

- Instead of duplicating info about required link types into the `links` yaml object we could have parsed the `_links` object and evaluated the required link types from there. That would have made it a single source of truth for declaring required link types. But the drawbacks are a more complex json generator and also possibly a lacking possibility to specify what version of the generic EiffelEventLink definition to use per event type. As a mitigation for this a check has been implemented to compare the `links` object with the `_links` object.
- Could also have included validation of _available_ link types, not just the _required_ ones, but in line with comments in #148 that might not be desired. A separate issue could be raised to discuss whether or not to validate available link types as well, and how to deal with custom link types if so.

### Benefits
Validation of required links in json schema instead of being hard coded in each event publisher implementation

### Possible Drawbacks
Previously approved events could now be disallowed, if the event producer accepted events without some required link types as described in the md docs.

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Emil Bäckmark emil.backmark@ericsson.com