### PR TITLE
Add _name and _version fields to all definition files

### DIFF
--- a/definitions/EiffelActivityCanceledEvent/1.0.0.yml
+++ b/definitions/EiffelActivityCanceledEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelActivityCanceledEvent
+_version: 1.0.0
 _abbrev: ActC
 _description: The EiffelActivityCanceledEvent signals that a previously
   triggered activity execution has been canceled _before it has started_.

--- a/definitions/EiffelActivityCanceledEvent/1.1.0.yml
+++ b/definitions/EiffelActivityCanceledEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelActivityCanceledEvent
+_version: 1.1.0
 _abbrev: ActC
 _description: The EiffelActivityCanceledEvent signals that a previously
   triggered activity execution has been canceled _before it has started_.

--- a/definitions/EiffelActivityCanceledEvent/2.0.0.yml
+++ b/definitions/EiffelActivityCanceledEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelActivityCanceledEvent
+_version: 2.0.0
 _abbrev: ActC
 _description: The EiffelActivityCanceledEvent signals that a previously
   triggered activity execution has been canceled _before it has started_.

--- a/definitions/EiffelActivityCanceledEvent/3.0.0.yml
+++ b/definitions/EiffelActivityCanceledEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelActivityCanceledEvent
+_version: 3.0.0
 _abbrev: ActC
 _description: The EiffelActivityCanceledEvent signals that a previously
   triggered activity execution has been canceled _before it has started_.

--- a/definitions/EiffelActivityCanceledEvent/3.1.0.yml
+++ b/definitions/EiffelActivityCanceledEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelActivityCanceledEvent
+_version: 3.1.0
 _abbrev: ActC
 _description: The EiffelActivityCanceledEvent signals that a previously
   triggered activity execution has been canceled _before it has started_.

--- a/definitions/EiffelActivityCanceledEvent/3.2.0.yml
+++ b/definitions/EiffelActivityCanceledEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelActivityCanceledEvent
+_version: 3.2.0
 _abbrev: ActC
 _description: The EiffelActivityCanceledEvent signals that a previously
   triggered activity execution has been canceled _before it has started_.

--- a/definitions/EiffelActivityCanceledEvent/4.0.0.yml
+++ b/definitions/EiffelActivityCanceledEvent/4.0.0.yml
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelActivityCanceledEvent
+_version: 4.0.0
 _abbrev: ActC
 _description: The EiffelActivityCanceledEvent signals that a previously
   triggered activity execution has been canceled _before it has started_.

--- a/definitions/EiffelActivityFinishedEvent/1.0.0.yml
+++ b/definitions/EiffelActivityFinishedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelActivityFinishedEvent
+_version: 1.0.0
 _abbrev: ActF
 _description: The EiffelActivityFinishedEvent declares that a previously
   started activity (declared by [EiffelActivityTriggeredEvent](./EiffelActivityTriggeredEvent.md)

--- a/definitions/EiffelActivityFinishedEvent/1.1.0.yml
+++ b/definitions/EiffelActivityFinishedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelActivityFinishedEvent
+_version: 1.1.0
 _abbrev: ActF
 _description: The EiffelActivityFinishedEvent declares that a previously
   started activity (declared by [EiffelActivityTriggeredEvent](./EiffelActivityTriggeredEvent.md)

--- a/definitions/EiffelActivityFinishedEvent/2.0.0.yml
+++ b/definitions/EiffelActivityFinishedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelActivityFinishedEvent
+_version: 2.0.0
 _abbrev: ActF
 _description: The EiffelActivityFinishedEvent declares that a previously
   started activity (declared by [EiffelActivityTriggeredEvent](./EiffelActivityTriggeredEvent.md)

--- a/definitions/EiffelActivityFinishedEvent/3.0.0.yml
+++ b/definitions/EiffelActivityFinishedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelActivityFinishedEvent
+_version: 3.0.0
 _abbrev: ActF
 _description: The EiffelActivityFinishedEvent declares that a previously
   started activity (declared by [EiffelActivityTriggeredEvent](./EiffelActivityTriggeredEvent.md)

--- a/definitions/EiffelActivityFinishedEvent/3.1.0.yml
+++ b/definitions/EiffelActivityFinishedEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelActivityFinishedEvent
+_version: 3.1.0
 _abbrev: ActF
 _description: The EiffelActivityFinishedEvent declares that a previously
   started activity (declared by [EiffelActivityTriggeredEvent](./EiffelActivityTriggeredEvent.md)

--- a/definitions/EiffelActivityFinishedEvent/3.2.0.yml
+++ b/definitions/EiffelActivityFinishedEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelActivityFinishedEvent
+_version: 3.2.0
 _abbrev: ActF
 _description: The EiffelActivityFinishedEvent declares that a previously
   started activity (declared by [EiffelActivityTriggeredEvent](./EiffelActivityTriggeredEvent.md)

--- a/definitions/EiffelActivityFinishedEvent/3.3.0.yml
+++ b/definitions/EiffelActivityFinishedEvent/3.3.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelActivityFinishedEvent
+_version: 3.3.0
 _abbrev: ActF
 _description: The EiffelActivityFinishedEvent declares that a previously
   started activity (declared by [EiffelActivityTriggeredEvent](./EiffelActivityTriggeredEvent.md)

--- a/definitions/EiffelActivityStartedEvent/1.0.0.yml
+++ b/definitions/EiffelActivityStartedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelActivityStartedEvent
+_version: 1.0.0
 _abbrev: ActS
 _description: The EiffelActivityStartedEvent declares that a previously
   triggered activity (declared by [EiffelActivityTriggeredEvent](./EiffelActivityTriggeredEvent.md))

--- a/definitions/EiffelActivityStartedEvent/1.1.0.yml
+++ b/definitions/EiffelActivityStartedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelActivityStartedEvent
+_version: 1.1.0
 _abbrev: ActS
 _description: The EiffelActivityStartedEvent declares that a previously
   triggered activity (declared by [EiffelActivityTriggeredEvent](./EiffelActivityTriggeredEvent.md))

--- a/definitions/EiffelActivityStartedEvent/2.0.0.yml
+++ b/definitions/EiffelActivityStartedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelActivityStartedEvent
+_version: 2.0.0
 _abbrev: ActS
 _description: The EiffelActivityStartedEvent declares that a previously
   triggered activity (declared by [EiffelActivityTriggeredEvent](./EiffelActivityTriggeredEvent.md))

--- a/definitions/EiffelActivityStartedEvent/3.0.0.yml
+++ b/definitions/EiffelActivityStartedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelActivityStartedEvent
+_version: 3.0.0
 _abbrev: ActS
 _description: The EiffelActivityStartedEvent declares that a previously
   triggered activity (declared by [EiffelActivityTriggeredEvent](./EiffelActivityTriggeredEvent.md))

--- a/definitions/EiffelActivityStartedEvent/4.0.0.yml
+++ b/definitions/EiffelActivityStartedEvent/4.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelActivityStartedEvent
+_version: 4.0.0
 _abbrev: ActS
 _description: The EiffelActivityStartedEvent declares that a previously
   triggered activity (declared by [EiffelActivityTriggeredEvent](./EiffelActivityTriggeredEvent.md))

--- a/definitions/EiffelActivityStartedEvent/4.1.0.yml
+++ b/definitions/EiffelActivityStartedEvent/4.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelActivityStartedEvent
+_version: 4.1.0
 _abbrev: ActS
 _description: The EiffelActivityStartedEvent declares that a previously
   triggered activity (declared by [EiffelActivityTriggeredEvent](./EiffelActivityTriggeredEvent.md))

--- a/definitions/EiffelActivityStartedEvent/4.2.0.yml
+++ b/definitions/EiffelActivityStartedEvent/4.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelActivityStartedEvent
+_version: 4.2.0
 _abbrev: ActS
 _description: The EiffelActivityStartedEvent declares that a previously
   triggered activity (declared by [EiffelActivityTriggeredEvent](./EiffelActivityTriggeredEvent.md))

--- a/definitions/EiffelActivityStartedEvent/4.3.0.yml
+++ b/definitions/EiffelActivityStartedEvent/4.3.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelActivityStartedEvent
+_version: 4.3.0
 _abbrev: ActS
 _description: The EiffelActivityStartedEvent declares that a previously
   triggered activity (declared by [EiffelActivityTriggeredEvent](./EiffelActivityTriggeredEvent.md))

--- a/definitions/EiffelActivityTriggeredEvent/1.0.0.yml
+++ b/definitions/EiffelActivityTriggeredEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelActivityTriggeredEvent
+_version: 1.0.0
 _abbrev: ActT
 _description: |-
   The EiffelActivityTriggeredEvent declares that a certain activity - typically a build, test or analysis activity - has been triggered by some factor. Note that this is crucially different from the activity execution having _started_ (as declared by [EiffelActivityStartedEvent](./EiffelActivityStartedEvent.md)).

--- a/definitions/EiffelActivityTriggeredEvent/1.1.0.yml
+++ b/definitions/EiffelActivityTriggeredEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelActivityTriggeredEvent
+_version: 1.1.0
 _abbrev: ActT
 _description: |-
   The EiffelActivityTriggeredEvent declares that a certain activity - typically a build, test or analysis activity - has been triggered by some factor. Note that this is crucially different from the activity execution having _started_ (as declared by [EiffelActivityStartedEvent](./EiffelActivityStartedEvent.md)).

--- a/definitions/EiffelActivityTriggeredEvent/2.0.0.yml
+++ b/definitions/EiffelActivityTriggeredEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelActivityTriggeredEvent
+_version: 2.0.0
 _abbrev: ActT
 _description: |-
   The EiffelActivityTriggeredEvent declares that a certain activity - typically a build, test or analysis activity - has been triggered by some factor. Note that this is crucially different from the activity execution having _started_ (as declared by [EiffelActivityStartedEvent](./EiffelActivityStartedEvent.md)).

--- a/definitions/EiffelActivityTriggeredEvent/3.0.0.yml
+++ b/definitions/EiffelActivityTriggeredEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelActivityTriggeredEvent
+_version: 3.0.0
 _abbrev: ActT
 _description: |-
   The EiffelActivityTriggeredEvent declares that a certain activity - typically a build, test or analysis activity - has been triggered by some factor. Note that this is crucially different from the activity execution having _started_ (as declared by [EiffelActivityStartedEvent](./EiffelActivityStartedEvent.md)).

--- a/definitions/EiffelActivityTriggeredEvent/4.0.0.yml
+++ b/definitions/EiffelActivityTriggeredEvent/4.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelActivityTriggeredEvent
+_version: 4.0.0
 _abbrev: ActT
 _description: |-
   The EiffelActivityTriggeredEvent declares that a certain activity - typically a build, test or analysis activity - has been triggered by some factor. Note that this is crucially different from the activity execution having _started_ (as declared by [EiffelActivityStartedEvent](./EiffelActivityStartedEvent.md)).

--- a/definitions/EiffelActivityTriggeredEvent/4.1.0.yml
+++ b/definitions/EiffelActivityTriggeredEvent/4.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelActivityTriggeredEvent
+_version: 4.1.0
 _abbrev: ActT
 _description: |-
   The EiffelActivityTriggeredEvent declares that a certain activity - typically a build, test or analysis activity - has been triggered by some factor. Note that this is crucially different from the activity execution having _started_ (as declared by [EiffelActivityStartedEvent](./EiffelActivityStartedEvent.md)).

--- a/definitions/EiffelActivityTriggeredEvent/4.2.0.yml
+++ b/definitions/EiffelActivityTriggeredEvent/4.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelActivityTriggeredEvent
+_version: 4.2.0
 _abbrev: ActT
 _description: |-
   The EiffelActivityTriggeredEvent declares that a certain activity - typically a build, test or analysis activity - has been triggered by some factor. Note that this is crucially different from the activity execution having _started_ (as declared by [EiffelActivityStartedEvent](./EiffelActivityStartedEvent.md)).

--- a/definitions/EiffelActivityTriggeredEvent/4.3.0.yml
+++ b/definitions/EiffelActivityTriggeredEvent/4.3.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelActivityTriggeredEvent
+_version: 4.3.0
 _abbrev: ActT
 _description: |-
   The EiffelActivityTriggeredEvent declares that a certain activity - typically a build, test or analysis activity - has been triggered by some factor. Note that this is crucially different from the activity execution having _started_ (as declared by [EiffelActivityStartedEvent](./EiffelActivityStartedEvent.md)).

--- a/definitions/EiffelAnnouncementPublishedEvent/1.0.0.yml
+++ b/definitions/EiffelAnnouncementPublishedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelAnnouncementPublishedEvent
+_version: 1.0.0
 _abbrev: AnnP
 _description: The EiffelAnnouncementPublishedEvent represents an announcement,
   technically regarding any topic but typically used to communicate

--- a/definitions/EiffelAnnouncementPublishedEvent/1.1.0.yml
+++ b/definitions/EiffelAnnouncementPublishedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelAnnouncementPublishedEvent
+_version: 1.1.0
 _abbrev: AnnP
 _description: The EiffelAnnouncementPublishedEvent represents an announcement,
   technically regarding any topic but typically used to communicate

--- a/definitions/EiffelAnnouncementPublishedEvent/2.0.0.yml
+++ b/definitions/EiffelAnnouncementPublishedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelAnnouncementPublishedEvent
+_version: 2.0.0
 _abbrev: AnnP
 _description: The EiffelAnnouncementPublishedEvent represents an announcement,
   technically regarding any topic but typically used to communicate

--- a/definitions/EiffelAnnouncementPublishedEvent/3.0.0.yml
+++ b/definitions/EiffelAnnouncementPublishedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelAnnouncementPublishedEvent
+_version: 3.0.0
 _abbrev: AnnP
 _description: The EiffelAnnouncementPublishedEvent represents an announcement,
   technically regarding any topic but typically used to communicate

--- a/definitions/EiffelAnnouncementPublishedEvent/3.1.0.yml
+++ b/definitions/EiffelAnnouncementPublishedEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelAnnouncementPublishedEvent
+_version: 3.1.0
 _abbrev: AnnP
 _description: The EiffelAnnouncementPublishedEvent represents an announcement,
   technically regarding any topic but typically used to communicate

--- a/definitions/EiffelAnnouncementPublishedEvent/3.2.0.yml
+++ b/definitions/EiffelAnnouncementPublishedEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelAnnouncementPublishedEvent
+_version: 3.2.0
 _abbrev: AnnP
 _description: The EiffelAnnouncementPublishedEvent represents an announcement,
   technically regarding any topic but typically used to communicate

--- a/definitions/EiffelArtifactCreatedEvent/1.0.0.yml
+++ b/definitions/EiffelArtifactCreatedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelArtifactCreatedEvent
+_version: 1.0.0
 _abbrev: ArtC
 _description: The EiffelArtifactCreatedEvent declares that a software
   artifact has been created, what its coordinates are, what it contains

--- a/definitions/EiffelArtifactCreatedEvent/1.1.0.yml
+++ b/definitions/EiffelArtifactCreatedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelArtifactCreatedEvent
+_version: 1.1.0
 _abbrev: ArtC
 _description: The EiffelArtifactCreatedEvent declares that a software
   artifact has been created, what its coordinates are, what it contains

--- a/definitions/EiffelArtifactCreatedEvent/2.0.0.yml
+++ b/definitions/EiffelArtifactCreatedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelArtifactCreatedEvent
+_version: 2.0.0
 _abbrev: ArtC
 _description: The EiffelArtifactCreatedEvent declares that a software
   artifact has been created, what its coordinates are, what it contains

--- a/definitions/EiffelArtifactCreatedEvent/3.0.0.yml
+++ b/definitions/EiffelArtifactCreatedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelArtifactCreatedEvent
+_version: 3.0.0
 _abbrev: ArtC
 _description: The EiffelArtifactCreatedEvent declares that a software
   artifact has been created, what its coordinates are, what it contains

--- a/definitions/EiffelArtifactCreatedEvent/3.1.0.yml
+++ b/definitions/EiffelArtifactCreatedEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelArtifactCreatedEvent
+_version: 3.1.0
 _abbrev: ArtC
 _description: The EiffelArtifactCreatedEvent declares that a software
   artifact has been created, what its coordinates are, what it contains

--- a/definitions/EiffelArtifactCreatedEvent/3.2.0.yml
+++ b/definitions/EiffelArtifactCreatedEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelArtifactCreatedEvent
+_version: 3.2.0
 _abbrev: ArtC
 _description: The EiffelArtifactCreatedEvent declares that a software
   artifact has been created, what its coordinates are, what it contains

--- a/definitions/EiffelArtifactCreatedEvent/3.3.0.yml
+++ b/definitions/EiffelArtifactCreatedEvent/3.3.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelArtifactCreatedEvent
+_version: 3.3.0
 _abbrev: ArtC
 _description: The EiffelArtifactCreatedEvent declares that a software
   artifact has been created, what its coordinates are, what it contains

--- a/definitions/EiffelArtifactDeployedEvent/0.1.0.yml
+++ b/definitions/EiffelArtifactDeployedEvent/0.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2022 Axis Communications AB.
+# Copyright 2022-2024 Axis Communications AB.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelArtifactDeployedEvent
+_version: 0.1.0
 _abbrev: ArtD
 _description: The EiffelArtifactDeployedEvent states that a software artifact had been deployed into a specified environment or
   that the configuration of the artifact has been changed.

--- a/definitions/EiffelArtifactPublishedEvent/1.0.0.yml
+++ b/definitions/EiffelArtifactPublishedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelArtifactPublishedEvent
+_version: 1.0.0
 _abbrev: ArtP
 _description: The EiffelArtifactPublishedEvent declares that a software
   artifact (declared by [EiffelArtifactCreatedEvent](./EiffelArtifactCreatedEvent.md))

--- a/definitions/EiffelArtifactPublishedEvent/1.1.0.yml
+++ b/definitions/EiffelArtifactPublishedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelArtifactPublishedEvent
+_version: 1.1.0
 _abbrev: ArtP
 _description: The EiffelArtifactPublishedEvent declares that a software
   artifact (declared by [EiffelArtifactCreatedEvent](./EiffelArtifactCreatedEvent.md))

--- a/definitions/EiffelArtifactPublishedEvent/2.0.0.yml
+++ b/definitions/EiffelArtifactPublishedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelArtifactPublishedEvent
+_version: 2.0.0
 _abbrev: ArtP
 _description: The EiffelArtifactPublishedEvent declares that a software
   artifact (declared by [EiffelArtifactCreatedEvent](./EiffelArtifactCreatedEvent.md))

--- a/definitions/EiffelArtifactPublishedEvent/3.0.0.yml
+++ b/definitions/EiffelArtifactPublishedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelArtifactPublishedEvent
+_version: 3.0.0
 _abbrev: ArtP
 _description: The EiffelArtifactPublishedEvent declares that a software
   artifact (declared by [EiffelArtifactCreatedEvent](./EiffelArtifactCreatedEvent.md))

--- a/definitions/EiffelArtifactPublishedEvent/3.1.0.yml
+++ b/definitions/EiffelArtifactPublishedEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelArtifactPublishedEvent
+_version: 3.1.0
 _abbrev: ArtP
 _description: The EiffelArtifactPublishedEvent declares that a software
   artifact (declared by [EiffelArtifactCreatedEvent](./EiffelArtifactCreatedEvent.md))

--- a/definitions/EiffelArtifactPublishedEvent/3.2.0.yml
+++ b/definitions/EiffelArtifactPublishedEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelArtifactPublishedEvent
+_version: 3.2.0
 _abbrev: ArtP
 _description: The EiffelArtifactPublishedEvent declares that a software
   artifact (declared by [EiffelArtifactCreatedEvent](./EiffelArtifactCreatedEvent.md))

--- a/definitions/EiffelArtifactPublishedEvent/3.3.0.yml
+++ b/definitions/EiffelArtifactPublishedEvent/3.3.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelArtifactPublishedEvent
+_version: 3.3.0
 _abbrev: ArtP
 _description: The EiffelArtifactPublishedEvent declares that a software
   artifact (declared by [EiffelArtifactCreatedEvent](./EiffelArtifactCreatedEvent.md))

--- a/definitions/EiffelArtifactReusedEvent/1.0.0.yml
+++ b/definitions/EiffelArtifactReusedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelArtifactReusedEvent
+_version: 1.0.0
 _abbrev: ArtR
 _description: |-
   The EiffelArtifactReusedEvent declares that an identified [EiffelArtifactCreatedEvent](./EiffelArtifactCreatedEvent.md) has been _reused_ for an identified [EiffelCompositionDefinedEvent](./EiffelCompositionDefinedEvent.md). This means that it is logically equivalent to an artifact that would have been built from that composition, and can be used for build avoidance (see the [Build Avoidance Usage Example](../usage-examples/build-avoidance.md) for more information).

--- a/definitions/EiffelArtifactReusedEvent/1.1.0.yml
+++ b/definitions/EiffelArtifactReusedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelArtifactReusedEvent
+_version: 1.1.0
 _abbrev: ArtR
 _description: |-
   The EiffelArtifactReusedEvent declares that an identified [EiffelArtifactCreatedEvent](./EiffelArtifactCreatedEvent.md) has been _reused_ for an identified [EiffelCompositionDefinedEvent](./EiffelCompositionDefinedEvent.md). This means that it is logically equivalent to an artifact that would have been built from that composition, and can be used for build avoidance (see the [Build Avoidance Usage Example](../usage-examples/build-avoidance.md) for more information).

--- a/definitions/EiffelArtifactReusedEvent/2.0.0.yml
+++ b/definitions/EiffelArtifactReusedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelArtifactReusedEvent
+_version: 2.0.0
 _abbrev: ArtR
 _description: |-
   The EiffelArtifactReusedEvent declares that an identified [EiffelArtifactCreatedEvent](./EiffelArtifactCreatedEvent.md) has been _reused_ for an identified [EiffelCompositionDefinedEvent](./EiffelCompositionDefinedEvent.md). This means that it is logically equivalent to an artifact that would have been built from that composition, and can be used for build avoidance (see the [Build Avoidance Usage Example](../usage-examples/build-avoidance.md) for more information).

--- a/definitions/EiffelArtifactReusedEvent/3.0.0.yml
+++ b/definitions/EiffelArtifactReusedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelArtifactReusedEvent
+_version: 3.0.0
 _abbrev: ArtR
 _description: |-
   The EiffelArtifactReusedEvent declares that an identified [EiffelArtifactCreatedEvent](./EiffelArtifactCreatedEvent.md) has been _reused_ for an identified [EiffelCompositionDefinedEvent](./EiffelCompositionDefinedEvent.md). This means that it is logically equivalent to an artifact that would have been built from that composition, and can be used for build avoidance (see the [Build Avoidance Usage Example](../usage-examples/build-avoidance.md) for more information).

--- a/definitions/EiffelArtifactReusedEvent/3.1.0.yml
+++ b/definitions/EiffelArtifactReusedEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelArtifactReusedEvent
+_version: 3.1.0
 _abbrev: ArtR
 _description: |-
   The EiffelArtifactReusedEvent declares that an identified [EiffelArtifactCreatedEvent](./EiffelArtifactCreatedEvent.md) has been _reused_ for an identified [EiffelCompositionDefinedEvent](./EiffelCompositionDefinedEvent.md). This means that it is logically equivalent to an artifact that would have been built from that composition, and can be used for build avoidance (see the [Build Avoidance Usage Example](../usage-examples/build-avoidance.md) for more information).

--- a/definitions/EiffelArtifactReusedEvent/3.2.0.yml
+++ b/definitions/EiffelArtifactReusedEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelArtifactReusedEvent
+_version: 3.2.0
 _abbrev: ArtR
 _description: |-
   The EiffelArtifactReusedEvent declares that an identified [EiffelArtifactCreatedEvent](./EiffelArtifactCreatedEvent.md) has been _reused_ for an identified [EiffelCompositionDefinedEvent](./EiffelCompositionDefinedEvent.md). This means that it is logically equivalent to an artifact that would have been built from that composition, and can be used for build avoidance (see the [Build Avoidance Usage Example](../usage-examples/build-avoidance.md) for more information).

--- a/definitions/EiffelCompositionDefinedEvent/1.0.0.yml
+++ b/definitions/EiffelCompositionDefinedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelCompositionDefinedEvent
+_version: 1.0.0
 _abbrev: CD
 _description: The EiffelCompositionDefinedEvent declares a composition
   of items (artifacts, sources and other compositions) has been defined,

--- a/definitions/EiffelCompositionDefinedEvent/1.1.0.yml
+++ b/definitions/EiffelCompositionDefinedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelCompositionDefinedEvent
+_version: 1.1.0
 _abbrev: CD
 _description: The EiffelCompositionDefinedEvent declares a composition
   of items (artifacts, sources and other compositions) has been defined,

--- a/definitions/EiffelCompositionDefinedEvent/2.0.0.yml
+++ b/definitions/EiffelCompositionDefinedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelCompositionDefinedEvent
+_version: 2.0.0
 _abbrev: CD
 _description: The EiffelCompositionDefinedEvent declares a composition
   of items (artifacts, sources and other compositions) has been defined,

--- a/definitions/EiffelCompositionDefinedEvent/3.0.0.yml
+++ b/definitions/EiffelCompositionDefinedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelCompositionDefinedEvent
+_version: 3.0.0
 _abbrev: CD
 _description: The EiffelCompositionDefinedEvent declares a composition
   of items (artifacts, sources and other compositions) has been defined,

--- a/definitions/EiffelCompositionDefinedEvent/3.1.0.yml
+++ b/definitions/EiffelCompositionDefinedEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelCompositionDefinedEvent
+_version: 3.1.0
 _abbrev: CD
 _description: The EiffelCompositionDefinedEvent declares a composition
   of items (artifacts, sources and other compositions) has been defined,

--- a/definitions/EiffelCompositionDefinedEvent/3.2.0.yml
+++ b/definitions/EiffelCompositionDefinedEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelCompositionDefinedEvent
+_version: 3.2.0
 _abbrev: CD
 _description: The EiffelCompositionDefinedEvent declares a composition
   of items (artifacts, sources and other compositions) has been defined,

--- a/definitions/EiffelCompositionDefinedEvent/3.3.0.yml
+++ b/definitions/EiffelCompositionDefinedEvent/3.3.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelCompositionDefinedEvent
+_version: 3.3.0
 _abbrev: CD
 _description: The EiffelCompositionDefinedEvent declares a composition
   of items (artifacts, sources and other compositions) has been defined,

--- a/definitions/EiffelConfidenceLevelModifiedEvent/1.0.0.yml
+++ b/definitions/EiffelConfidenceLevelModifiedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelConfidenceLevelModifiedEvent
+_version: 1.0.0
 _abbrev: CLM
 _description: |-
   The EiffelConfidenceLevelModifiedEvent declares that an entity has achieved (or failed to achieve) a certain level of confidence, or in a broader sense to annotate it as being applicable or relevant to a certain case (e.g. fit for release to a certain customer segment or having passed certain criteria. This is particularly useful for promoting various engineering artifacts, such as product revisions, through the continuous integration and delivery pipeline.

--- a/definitions/EiffelConfidenceLevelModifiedEvent/1.1.0.yml
+++ b/definitions/EiffelConfidenceLevelModifiedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelConfidenceLevelModifiedEvent
+_version: 1.1.0
 _abbrev: CLM
 _description: |-
   The EiffelConfidenceLevelModifiedEvent declares that an entity has achieved (or failed to achieve) a certain level of confidence, or in a broader sense to annotate it as being applicable or relevant to a certain case (e.g. fit for release to a certain customer segment or having passed certain criteria). This is particularly useful for promoting various engineering artifacts, such as product revisions, through the continuous integration and delivery pipeline.

--- a/definitions/EiffelConfidenceLevelModifiedEvent/2.0.0.yml
+++ b/definitions/EiffelConfidenceLevelModifiedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelConfidenceLevelModifiedEvent
+_version: 2.0.0
 _abbrev: CLM
 _description: |-
   The EiffelConfidenceLevelModifiedEvent declares that an entity has achieved (or failed to achieve) a certain level of confidence, or in a broader sense to annotate it as being applicable or relevant to a certain case (e.g. fit for release to a certain customer segment or having passed certain criteria). This is particularly useful for promoting various engineering artifacts, such as product revisions, through the continuous integration and delivery pipeline.

--- a/definitions/EiffelConfidenceLevelModifiedEvent/3.0.0.yml
+++ b/definitions/EiffelConfidenceLevelModifiedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelConfidenceLevelModifiedEvent
+_version: 3.0.0
 _abbrev: CLM
 _description: |-
   The EiffelConfidenceLevelModifiedEvent declares that an entity has achieved (or failed to achieve) a certain level of confidence, or in a broader sense to annotate it as being applicable or relevant to a certain case (e.g. fit for release to a certain customer segment or having passed certain criteria). This is particularly useful for promoting various engineering artifacts, such as product revisions, through the continuous integration and delivery pipeline.

--- a/definitions/EiffelConfidenceLevelModifiedEvent/3.1.0.yml
+++ b/definitions/EiffelConfidenceLevelModifiedEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelConfidenceLevelModifiedEvent
+_version: 3.1.0
 _abbrev: CLM
 _description: |-
   The EiffelConfidenceLevelModifiedEvent declares that an entity has achieved (or failed to achieve) a certain level of confidence, or in a broader sense to annotate it as being applicable or relevant to a certain case (e.g. fit for release to a certain customer segment or having passed certain criteria). This is particularly useful for promoting various engineering artifacts, such as product revisions, through the continuous integration and delivery pipeline.

--- a/definitions/EiffelConfidenceLevelModifiedEvent/3.2.0.yml
+++ b/definitions/EiffelConfidenceLevelModifiedEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelConfidenceLevelModifiedEvent
+_version: 3.2.0
 _abbrev: CLM
 _description: |-
   The EiffelConfidenceLevelModifiedEvent declares that an entity has achieved (or failed to achieve) a certain level of confidence, or in a broader sense to annotate it as being applicable or relevant to a certain case (e.g. fit for release to a certain customer segment or having passed certain criteria). This is particularly useful for promoting various engineering artifacts, such as product revisions, through the continuous integration and delivery pipeline.

--- a/definitions/EiffelConfidenceLevelModifiedEvent/3.3.0.yml
+++ b/definitions/EiffelConfidenceLevelModifiedEvent/3.3.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelConfidenceLevelModifiedEvent
+_version: 3.3.0
 _abbrev: CLM
 _description: |-
   The EiffelConfidenceLevelModifiedEvent declares that an entity has achieved (or failed to achieve) a certain level of confidence, or in a broader sense to annotate it as being applicable or relevant to a certain case (e.g. fit for release to a certain customer segment or having passed certain criteria). This is particularly useful for promoting various engineering artifacts, such as product revisions, through the continuous integration and delivery pipeline.

--- a/definitions/EiffelConfidenceLevelModifiedEvent/3.4.0.yml
+++ b/definitions/EiffelConfidenceLevelModifiedEvent/3.4.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelConfidenceLevelModifiedEvent
+_version: 3.4.0
 _abbrev: CLM
 _description: |-
   The EiffelConfidenceLevelModifiedEvent declares that an entity has achieved (or failed to achieve) a certain level of confidence, or in a broader sense to annotate it as being applicable or relevant to a certain case (e.g. fit for release to a certain customer segment or having passed certain criteria). This is particularly useful for promoting various engineering artifacts, such as product revisions, through the continuous integration and delivery pipeline.

--- a/definitions/EiffelCustomDataProperty/1.0.0.yml
+++ b/definitions/EiffelCustomDataProperty/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelCustomDataProperty
+_version: 1.0.0
 type: object
 properties:
   key:

--- a/definitions/EiffelEnvironmentDefinedEvent/1.0.0.yml
+++ b/definitions/EiffelEnvironmentDefinedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelEnvironmentDefinedEvent
+_version: 1.0.0
 _abbrev: ED
 _description: |-
   The EiffelEnvironmentDefinedEvent declares an environment which may be referenced from other events in order to secure traceability to the conditions under which an artifact was created or a test was executed. Depending on the technology domain, the nature of an environment varies greatly however: it may be a virtual image, a complete mechatronic system of millions of independent parts, or anything in between. Consequently, a concise yet complete and generic syntax for describing any environment is futile.

--- a/definitions/EiffelEnvironmentDefinedEvent/1.1.0.yml
+++ b/definitions/EiffelEnvironmentDefinedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelEnvironmentDefinedEvent
+_version: 1.1.0
 _abbrev: ED
 _description: |-
   The EiffelEnvironmentDefinedEvent declares an environment which may be referenced from other events in order to secure traceability to the conditions under which an artifact was created or a test was executed. Depending on the technology domain, the nature of an environment varies greatly however: it may be a virtual image, a complete mechatronic system of millions of independent parts, or anything in between. Consequently, a concise yet complete and generic syntax for describing any environment is futile.

--- a/definitions/EiffelEnvironmentDefinedEvent/2.0.0.yml
+++ b/definitions/EiffelEnvironmentDefinedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelEnvironmentDefinedEvent
+_version: 2.0.0
 _abbrev: ED
 _description: |-
   The EiffelEnvironmentDefinedEvent declares an environment which may be referenced from other events in order to secure traceability to the conditions under which an artifact was created or a test was executed. Depending on the technology domain, the nature of an environment varies greatly however: it may be a virtual image, a complete mechatronic system of millions of independent parts, or anything in between. Consequently, a concise yet complete and generic syntax for describing any environment is futile.

--- a/definitions/EiffelEnvironmentDefinedEvent/3.0.0.yml
+++ b/definitions/EiffelEnvironmentDefinedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelEnvironmentDefinedEvent
+_version: 3.0.0
 _abbrev: ED
 _description: |-
   The EiffelEnvironmentDefinedEvent declares an environment which may be referenced from other events in order to secure traceability to the conditions under which an artifact was created or a test was executed. Depending on the technology domain, the nature of an environment varies greatly however: it may be a virtual image, a complete mechatronic system of millions of independent parts, or anything in between. Consequently, a concise yet complete and generic syntax for describing any environment is futile.

--- a/definitions/EiffelEnvironmentDefinedEvent/3.1.0.yml
+++ b/definitions/EiffelEnvironmentDefinedEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelEnvironmentDefinedEvent
+_version: 3.1.0
 _abbrev: ED
 _description: |-
   The EiffelEnvironmentDefinedEvent declares an environment which may be referenced from other events in order to secure traceability to the conditions under which an artifact was created or a test was executed. Depending on the technology domain, the nature of an environment varies greatly however: it may be a virtual image, a complete mechatronic system of millions of independent parts, or anything in between. Consequently, a concise yet complete and generic syntax for describing any environment is futile.

--- a/definitions/EiffelEnvironmentDefinedEvent/3.2.0.yml
+++ b/definitions/EiffelEnvironmentDefinedEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelEnvironmentDefinedEvent
+_version: 3.2.0
 _abbrev: ED
 _description: |-
   The EiffelEnvironmentDefinedEvent declares an environment which may be referenced from other events in order to secure traceability to the conditions under which an artifact was created or a test was executed. Depending on the technology domain, the nature of an environment varies greatly however: it may be a virtual image, a complete mechatronic system of millions of independent parts, or anything in between. Consequently, a concise yet complete and generic syntax for describing any environment is futile.

--- a/definitions/EiffelEnvironmentDefinedEvent/3.3.0.yml
+++ b/definitions/EiffelEnvironmentDefinedEvent/3.3.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelEnvironmentDefinedEvent
+_version: 3.3.0
 _abbrev: ED
 _description: |-
   The EiffelEnvironmentDefinedEvent declares an environment which may be referenced from other events in order to secure traceability to the conditions under which an artifact was created or a test was executed. Depending on the technology domain, the nature of an environment varies greatly however: it may be a virtual image, a complete mechatronic system of millions of independent parts, or anything in between. Consequently, a concise yet complete and generic syntax for describing any environment is futile.

--- a/definitions/EiffelEventLink/1.0.0.yml
+++ b/definitions/EiffelEventLink/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelEventLink
+_version: 1.0.0
 type: object
 properties:
   type:

--- a/definitions/EiffelEventLink/1.0.1.yml
+++ b/definitions/EiffelEventLink/1.0.1.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelEventLink
+_version: 1.0.1
 type: object
 properties:
   type:

--- a/definitions/EiffelEventLink/1.1.0.yml
+++ b/definitions/EiffelEventLink/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelEventLink
+_version: 1.1.0
 type: object
 properties:
   type:

--- a/definitions/EiffelEventLink/1.1.1.yml
+++ b/definitions/EiffelEventLink/1.1.1.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelEventLink
+_version: 1.1.1
 type: object
 properties:
   type:

--- a/definitions/EiffelFlowContextDefinedEvent/1.0.0.yml
+++ b/definitions/EiffelFlowContextDefinedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelFlowContextDefinedEvent
+_version: 1.0.0
 _abbrev: FCD
 _description: |-
   The EiffelFlowContextDefined describes the context of other events, answering questions such as "Which project is change part of?" or "Which track does artifact belong to?". In this way it offers a method of classifying and structuring one's continuous integration and delivery system and thereby facilitaring traceability and searchability.

--- a/definitions/EiffelFlowContextDefinedEvent/1.1.0.yml
+++ b/definitions/EiffelFlowContextDefinedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelFlowContextDefinedEvent
+_version: 1.1.0
 _abbrev: FCD
 _description: |-
   The EiffelFlowContextDefinedEvent describes the context of other events, answering questions such as "Which project is this change part of?" or "Which track does this artifact belong to?". In this way it offers a method of classifying and structuring one's continuous integration and delivery system and thereby facilitating traceability and searchability.

--- a/definitions/EiffelFlowContextDefinedEvent/2.0.0.yml
+++ b/definitions/EiffelFlowContextDefinedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelFlowContextDefinedEvent
+_version: 2.0.0
 _abbrev: FCD
 _description: |-
   The EiffelFlowContextDefinedEvent describes the context of other events, answering questions such as "Which project is this change part of?" or "Which track does this artifact belong to?". In this way it offers a method of classifying and structuring one's continuous integration and delivery system and thereby facilitating traceability and searchability.

--- a/definitions/EiffelFlowContextDefinedEvent/3.0.0.yml
+++ b/definitions/EiffelFlowContextDefinedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelFlowContextDefinedEvent
+_version: 3.0.0
 _abbrev: FCD
 _description: |-
   The EiffelFlowContextDefinedEvent describes the context of other events, answering questions such as "Which project is this change part of?" or "Which track does this artifact belong to?". In this way it offers a method of classifying and structuring one's continuous integration and delivery system and thereby facilitating traceability and searchability.

--- a/definitions/EiffelFlowContextDefinedEvent/3.1.0.yml
+++ b/definitions/EiffelFlowContextDefinedEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelFlowContextDefinedEvent
+_version: 3.1.0
 _abbrev: FCD
 _description: |-
   The EiffelFlowContextDefinedEvent describes the context of other events, answering questions such as "Which project is this change part of?" or "Which track does this artifact belong to?". In this way it offers a method of classifying and structuring one's continuous integration and delivery system and thereby facilitating traceability and searchability.

--- a/definitions/EiffelFlowContextDefinedEvent/3.2.0.yml
+++ b/definitions/EiffelFlowContextDefinedEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelFlowContextDefinedEvent
+_version: 3.2.0
 _abbrev: FCD
 _description: |-
   The EiffelFlowContextDefinedEvent describes the context of other events, answering questions such as "Which project is this change part of?" or "Which track does this artifact belong to?". In this way it offers a method of classifying and structuring one's continuous integration and delivery system and thereby facilitating traceability and searchability.

--- a/definitions/EiffelIssueDefinedEvent/1.0.0.yml
+++ b/definitions/EiffelIssueDefinedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelIssueDefinedEvent
+_version: 1.0.0
 _abbrev: ID
 _description: The EiffelIssueDefinedEvent declares that an issue has
   been created in some external issue management software. ID is semantically

--- a/definitions/EiffelIssueDefinedEvent/2.0.0.yml
+++ b/definitions/EiffelIssueDefinedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelIssueDefinedEvent
+_version: 2.0.0
 _abbrev: ID
 _description: The EiffelIssueDefinedEvent declares that an issue has
   been created in some external issue management software. ID is semantically

--- a/definitions/EiffelIssueDefinedEvent/3.0.0.yml
+++ b/definitions/EiffelIssueDefinedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelIssueDefinedEvent
+_version: 3.0.0
 _abbrev: ID
 _description: The EiffelIssueDefinedEvent declares that an issue has
   been created in some external issue management software. ID is semantically

--- a/definitions/EiffelIssueDefinedEvent/3.1.0.yml
+++ b/definitions/EiffelIssueDefinedEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelIssueDefinedEvent
+_version: 3.1.0
 _abbrev: ID
 _description: The EiffelIssueDefinedEvent declares that an issue has
   been created in some external issue management software. ID is semantically

--- a/definitions/EiffelIssueDefinedEvent/3.2.0.yml
+++ b/definitions/EiffelIssueDefinedEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelIssueDefinedEvent
+_version: 3.2.0
 _abbrev: ID
 _description: The EiffelIssueDefinedEvent declares that an issue has
   been created in some external issue management software. ID is semantically

--- a/definitions/EiffelIssueVerifiedEvent/1.0.0.yml
+++ b/definitions/EiffelIssueVerifiedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelIssueVerifiedEvent
+_version: 1.0.0
 _abbrev: IV
 _description: The EiffelIssueVerifiedEvent declares that an issue,
   typically a requirement, has been verified by some means. It is different

--- a/definitions/EiffelIssueVerifiedEvent/1.1.0.yml
+++ b/definitions/EiffelIssueVerifiedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelIssueVerifiedEvent
+_version: 1.1.0
 _abbrev: IV
 _description: The EiffelIssueVerifiedEvent declares that an issue,
   typically a requirement, has been verified by some means. It is different

--- a/definitions/EiffelIssueVerifiedEvent/2.0.0.yml
+++ b/definitions/EiffelIssueVerifiedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelIssueVerifiedEvent
+_version: 2.0.0
 _abbrev: IV
 _description: |-
   The EiffelIssueVerifiedEvent declares that an issue, typically a requirement, has been verified by some means. It is different from [EiffelTestCaseFinishedEvent](./EiffelTestCaseFinishedEvent.md) in that multiple test case executions may serve as the basis for a single verification or, conversely, multiple issues may be verified based on a single test case execution.

--- a/definitions/EiffelIssueVerifiedEvent/3.0.0.yml
+++ b/definitions/EiffelIssueVerifiedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelIssueVerifiedEvent
+_version: 3.0.0
 _abbrev: IV
 _description: |-
   The EiffelIssueVerifiedEvent declares that an issue, typically a requirement, has been verified by some means. It is different from [EiffelTestCaseFinishedEvent](./EiffelTestCaseFinishedEvent.md) in that multiple test case executions may serve as the basis for a single verification or, conversely, multiple issues may be verified based on a single test case execution.

--- a/definitions/EiffelIssueVerifiedEvent/4.0.0.yml
+++ b/definitions/EiffelIssueVerifiedEvent/4.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelIssueVerifiedEvent
+_version: 4.0.0
 _abbrev: IV
 _description: |-
   The EiffelIssueVerifiedEvent declares that an issue, typically a requirement, has been verified by some means. It is different from [EiffelTestCaseFinishedEvent](./EiffelTestCaseFinishedEvent.md) in that multiple test case executions may serve as the basis for a single verification or, conversely, multiple issues may be verified based on a single test case execution.

--- a/definitions/EiffelIssueVerifiedEvent/4.1.0.yml
+++ b/definitions/EiffelIssueVerifiedEvent/4.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelIssueVerifiedEvent
+_version: 4.1.0
 _abbrev: IV
 _description: |-
   The EiffelIssueVerifiedEvent declares that an issue, typically a requirement, has been verified by some means. It is different from [EiffelTestCaseFinishedEvent](./EiffelTestCaseFinishedEvent.md) in that multiple test case executions may serve as the basis for a single verification or, conversely, multiple issues may be verified based on a single test case execution.

--- a/definitions/EiffelIssueVerifiedEvent/4.2.0.yml
+++ b/definitions/EiffelIssueVerifiedEvent/4.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelIssueVerifiedEvent
+_version: 4.2.0
 _abbrev: IV
 _description: |-
   The EiffelIssueVerifiedEvent declares that an issue, typically a requirement, has been verified by some means. It is different from [EiffelTestCaseFinishedEvent](./EiffelTestCaseFinishedEvent.md) in that multiple test case executions may serve as the basis for a single verification or, conversely, multiple issues may be verified based on a single test case execution.

--- a/definitions/EiffelIssueVerifiedEvent/4.3.0.yml
+++ b/definitions/EiffelIssueVerifiedEvent/4.3.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelIssueVerifiedEvent
+_version: 4.3.0
 _abbrev: IV
 _description: |-
   The EiffelIssueVerifiedEvent declares that an issue, typically a requirement, has been verified by some means. It is different from [EiffelTestCaseFinishedEvent](./EiffelTestCaseFinishedEvent.md) in that multiple test case executions may serve as the basis for a single verification or, conversely, multiple issues may be verified based on a single test case execution.

--- a/definitions/EiffelIssueVerifiedEvent/4.3.1.yml
+++ b/definitions/EiffelIssueVerifiedEvent/4.3.1.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelIssueVerifiedEvent
+_version: 4.3.1
 _abbrev: IV
 _description: |-
   The EiffelIssueVerifiedEvent declares that an issue, typically a requirement, has been verified by some means. It is different from [EiffelTestCaseFinishedEvent](./EiffelTestCaseFinishedEvent.md) in that multiple test case executions may serve as the basis for a single verification or, conversely, multiple issues may be verified based on a single test case execution.

--- a/definitions/EiffelMetaProperty/1.0.0.yml
+++ b/definitions/EiffelMetaProperty/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelMetaProperty
+_version: 1.0.0
 type: object
 properties:
   id:

--- a/definitions/EiffelMetaProperty/2.0.0.yml
+++ b/definitions/EiffelMetaProperty/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2022 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelMetaProperty
+_version: 2.0.0
 type: object
 properties:
   id:

--- a/definitions/EiffelMetaProperty/3.0.0.yml
+++ b/definitions/EiffelMetaProperty/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelMetaProperty
+_version: 3.0.0
 type: object
 properties:
   id:

--- a/definitions/EiffelMetaProperty/3.1.0.yml
+++ b/definitions/EiffelMetaProperty/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelMetaProperty
+_version: 3.1.0
 type: object
 properties:
   id:

--- a/definitions/EiffelSourceChangeCreatedEvent/1.0.0.yml
+++ b/definitions/EiffelSourceChangeCreatedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelSourceChangeCreatedEvent
+_version: 1.0.0
 _abbrev: SCC
 _description: |-
   The EiffelSourceChangeCreatedEvent declares that a change to sources has been made, but not yet submitted (see [EiffelSourceChangeSubmittedEvent](./EiffelSourceChangeSubmittedEvent.md)). This can be used to represent a change done on a private branch, undergoing review or made in a forked repository. Unlike EiffelSourceChangeSubmittedEvent, EiffelSourceChangeCreatedEvent _describes the change_ in terms of who authored it and which issues it addressed.

--- a/definitions/EiffelSourceChangeCreatedEvent/1.1.0.yml
+++ b/definitions/EiffelSourceChangeCreatedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelSourceChangeCreatedEvent
+_version: 1.1.0
 _abbrev: SCC
 _description: |-
   The EiffelSourceChangeCreatedEvent declares that a change to sources has been made, but not yet submitted (see [EiffelSourceChangeSubmittedEvent](./EiffelSourceChangeSubmittedEvent.md)). This can be used to represent a change done on a private branch, undergoing review or made in a forked repository. Unlike EiffelSourceChangeSubmittedEvent, EiffelSourceChangeCreatedEvent _describes the change_ in terms of who authored it and which issues it addressed.

--- a/definitions/EiffelSourceChangeCreatedEvent/2.0.0.yml
+++ b/definitions/EiffelSourceChangeCreatedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelSourceChangeCreatedEvent
+_version: 2.0.0
 _abbrev: SCC
 _description: |-
   The EiffelSourceChangeCreatedEvent declares that a change to sources has been made, but not yet submitted (see [EiffelSourceChangeSubmittedEvent](./EiffelSourceChangeSubmittedEvent.md)). This can be used to represent a change done on a private branch, undergoing review or made in a forked repository. Unlike EiffelSourceChangeSubmittedEvent, EiffelSourceChangeCreatedEvent _describes the change_ in terms of who authored it and which issues it addressed.

--- a/definitions/EiffelSourceChangeCreatedEvent/3.0.0.yml
+++ b/definitions/EiffelSourceChangeCreatedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelSourceChangeCreatedEvent
+_version: 3.0.0
 _abbrev: SCC
 _description: |-
   The EiffelSourceChangeCreatedEvent declares that a change to sources has been made, but not yet submitted (see [EiffelSourceChangeSubmittedEvent](./EiffelSourceChangeSubmittedEvent.md)). This can be used to represent a change done on a private branch, undergoing review or made in a forked repository. Unlike EiffelSourceChangeSubmittedEvent, EiffelSourceChangeCreatedEvent _describes the change_ in terms of who authored it and which issues it addressed.

--- a/definitions/EiffelSourceChangeCreatedEvent/4.0.0.yml
+++ b/definitions/EiffelSourceChangeCreatedEvent/4.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelSourceChangeCreatedEvent
+_version: 4.0.0
 _abbrev: SCC
 _description: |-
   The EiffelSourceChangeCreatedEvent declares that a change to sources has been made, but not yet submitted (see [EiffelSourceChangeSubmittedEvent](./EiffelSourceChangeSubmittedEvent.md)). This can be used to represent a change done on a private branch, undergoing review or made in a forked repository. Unlike EiffelSourceChangeSubmittedEvent, EiffelSourceChangeCreatedEvent _describes the change_ in terms of who authored it and which issues it addressed.

--- a/definitions/EiffelSourceChangeCreatedEvent/4.1.0.yml
+++ b/definitions/EiffelSourceChangeCreatedEvent/4.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelSourceChangeCreatedEvent
+_version: 4.1.0
 _abbrev: SCC
 _description: |-
   The EiffelSourceChangeCreatedEvent declares that a change to sources has been made, but not yet submitted (see [EiffelSourceChangeSubmittedEvent](./EiffelSourceChangeSubmittedEvent.md)). This can be used to represent a change done on a private branch, undergoing review or made in a forked repository. Unlike EiffelSourceChangeSubmittedEvent, EiffelSourceChangeCreatedEvent _describes the change_ in terms of who authored it and which issues it addressed.

--- a/definitions/EiffelSourceChangeCreatedEvent/4.2.0.yml
+++ b/definitions/EiffelSourceChangeCreatedEvent/4.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelSourceChangeCreatedEvent
+_version: 4.2.0
 _abbrev: SCC
 _description: |-
   The EiffelSourceChangeCreatedEvent declares that a change to sources has been made, but not yet submitted (see [EiffelSourceChangeSubmittedEvent](./EiffelSourceChangeSubmittedEvent.md)). This can be used to represent a change done on a private branch, undergoing review or made in a forked repository. Unlike EiffelSourceChangeSubmittedEvent, EiffelSourceChangeCreatedEvent _describes the change_ in terms of who authored it and which issues it addressed.

--- a/definitions/EiffelSourceChangeSubmittedEvent/1.0.0.yml
+++ b/definitions/EiffelSourceChangeSubmittedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelSourceChangeSubmittedEvent
+_version: 1.0.0
 _abbrev: SCS
 _description: |-
   The EiffelSourceChangeSubmittedEvent declares that a change has been integrated into to a shared source branch of interest (e.g. "master", "dev" or "mainline") as opposed to a private or local branch. Note that it does not describe what has changed, but instead uses the __CHANGE__ link type to reference [EiffelSourceChangeCreatedEvent](./EiffelSourceChangeCreatedEvent.md).

--- a/definitions/EiffelSourceChangeSubmittedEvent/1.1.0.yml
+++ b/definitions/EiffelSourceChangeSubmittedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelSourceChangeSubmittedEvent
+_version: 1.1.0
 _abbrev: SCS
 _description: |-
   The EiffelSourceChangeSubmittedEvent declares that a change has been integrated into to a shared source branch of interest (e.g. "master", "dev" or "mainline") as opposed to a private or local branch. Note that it does not describe what has changed, but instead uses the __CHANGE__ link type to reference [EiffelSourceChangeCreatedEvent](./EiffelSourceChangeCreatedEvent.md).

--- a/definitions/EiffelSourceChangeSubmittedEvent/2.0.0.yml
+++ b/definitions/EiffelSourceChangeSubmittedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelSourceChangeSubmittedEvent
+_version: 2.0.0
 _abbrev: SCS
 _description: |-
   The EiffelSourceChangeSubmittedEvent declares that a change has been integrated into to a shared source branch of interest (e.g. "master", "dev" or "mainline") as opposed to a private or local branch. Note that it does not describe what has changed, but instead uses the __CHANGE__ link type to reference [EiffelSourceChangeCreatedEvent](./EiffelSourceChangeCreatedEvent.md).

--- a/definitions/EiffelSourceChangeSubmittedEvent/3.0.0.yml
+++ b/definitions/EiffelSourceChangeSubmittedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelSourceChangeSubmittedEvent
+_version: 3.0.0
 _abbrev: SCS
 _description: |-
   The EiffelSourceChangeSubmittedEvent declares that a change has been integrated into to a shared source branch of interest (e.g. "master", "dev" or "mainline") as opposed to a private or local branch. Note that it does not describe what has changed, but instead uses the __CHANGE__ link type to reference [EiffelSourceChangeCreatedEvent](./EiffelSourceChangeCreatedEvent.md).

--- a/definitions/EiffelSourceChangeSubmittedEvent/3.1.0.yml
+++ b/definitions/EiffelSourceChangeSubmittedEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelSourceChangeSubmittedEvent
+_version: 3.1.0
 _abbrev: SCS
 _description: |-
   The EiffelSourceChangeSubmittedEvent declares that a change has been integrated into to a shared source branch of interest (e.g. "master", "dev" or "mainline") as opposed to a private or local branch. Note that it does not describe what has changed, but instead uses the __CHANGE__ link type to reference [EiffelSourceChangeCreatedEvent](./EiffelSourceChangeCreatedEvent.md).

--- a/definitions/EiffelSourceChangeSubmittedEvent/3.2.0.yml
+++ b/definitions/EiffelSourceChangeSubmittedEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelSourceChangeSubmittedEvent
+_version: 3.2.0
 _abbrev: SCS
 _description: |-
   The EiffelSourceChangeSubmittedEvent declares that a change has been integrated into to a shared source branch of interest (e.g. "master", "dev" or "mainline") as opposed to a private or local branch. Note that it does not describe what has changed, but instead uses the __CHANGE__ link type to reference [EiffelSourceChangeCreatedEvent](./EiffelSourceChangeCreatedEvent.md).

--- a/definitions/EiffelTestCaseCanceledEvent/1.0.0.yml
+++ b/definitions/EiffelTestCaseCanceledEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestCaseCanceledEvent
+_version: 1.0.0
 _abbrev: TCC
 _description: The EiffelTestCaseCanceledEvent declares that a previously
   triggered test case execution (represented by [EiffelTestCaseTriggeredEvent](./EiffelTestCaseTriggeredEvent.md))

--- a/definitions/EiffelTestCaseCanceledEvent/1.1.0.yml
+++ b/definitions/EiffelTestCaseCanceledEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestCaseCanceledEvent
+_version: 1.1.0
 _abbrev: TCC
 _description: The EiffelTestCaseCanceledEvent declares that a previously
   triggered test case execution (represented by [EiffelTestCaseTriggeredEvent](./EiffelTestCaseTriggeredEvent.md))

--- a/definitions/EiffelTestCaseCanceledEvent/2.0.0.yml
+++ b/definitions/EiffelTestCaseCanceledEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestCaseCanceledEvent
+_version: 2.0.0
 _abbrev: TCC
 _description: The EiffelTestCaseCanceledEvent declares that a previously
   triggered test case execution (represented by [EiffelTestCaseTriggeredEvent](./EiffelTestCaseTriggeredEvent.md))

--- a/definitions/EiffelTestCaseCanceledEvent/3.0.0.yml
+++ b/definitions/EiffelTestCaseCanceledEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestCaseCanceledEvent
+_version: 3.0.0
 _abbrev: TCC
 _description: The EiffelTestCaseCanceledEvent declares that a previously
   triggered test case execution (represented by [EiffelTestCaseTriggeredEvent](./EiffelTestCaseTriggeredEvent.md))

--- a/definitions/EiffelTestCaseCanceledEvent/3.1.0.yml
+++ b/definitions/EiffelTestCaseCanceledEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestCaseCanceledEvent
+_version: 3.1.0
 _abbrev: TCC
 _description: The EiffelTestCaseCanceledEvent declares that a previously
   triggered test case execution (represented by [EiffelTestCaseTriggeredEvent](./EiffelTestCaseTriggeredEvent.md))

--- a/definitions/EiffelTestCaseCanceledEvent/3.2.0.yml
+++ b/definitions/EiffelTestCaseCanceledEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestCaseCanceledEvent
+_version: 3.2.0
 _abbrev: TCC
 _description: The EiffelTestCaseCanceledEvent declares that a previously
   triggered test case execution (represented by [EiffelTestCaseTriggeredEvent](./EiffelTestCaseTriggeredEvent.md))

--- a/definitions/EiffelTestCaseFinishedEvent/1.0.0.yml
+++ b/definitions/EiffelTestCaseFinishedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestCaseFinishedEvent
+_version: 1.0.0
 _abbrev: TCF
 _description: |-
   The EiffelTestCaseFinishedEvent declares that a previously started test case (declared by [EiffelTestCaseStartedEvent](./EiffelTestCaseStartedEvent.md)) has finished and reports the outcome.

--- a/definitions/EiffelTestCaseFinishedEvent/1.0.1.yml
+++ b/definitions/EiffelTestCaseFinishedEvent/1.0.1.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestCaseFinishedEvent
+_version: 1.0.1
 _abbrev: TCF
 _description: |-
   The EiffelTestCaseFinishedEvent declares that a previously started test case (declared by [EiffelTestCaseStartedEvent](./EiffelTestCaseStartedEvent.md)) has finished and reports the outcome.

--- a/definitions/EiffelTestCaseFinishedEvent/1.1.0.yml
+++ b/definitions/EiffelTestCaseFinishedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestCaseFinishedEvent
+_version: 1.1.0
 _abbrev: TCF
 _description: |-
   The EiffelTestCaseFinishedEvent declares that a previously started test case (declared by [EiffelTestCaseStartedEvent](./EiffelTestCaseStartedEvent.md)) has finished and reports the outcome.

--- a/definitions/EiffelTestCaseFinishedEvent/2.0.0.yml
+++ b/definitions/EiffelTestCaseFinishedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestCaseFinishedEvent
+_version: 2.0.0
 _abbrev: TCF
 _description: |-
   The EiffelTestCaseFinishedEvent declares that a previously started test case (declared by [EiffelTestCaseStartedEvent](./EiffelTestCaseStartedEvent.md)) has finished and reports the outcome.

--- a/definitions/EiffelTestCaseFinishedEvent/3.0.0.yml
+++ b/definitions/EiffelTestCaseFinishedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestCaseFinishedEvent
+_version: 3.0.0
 _abbrev: TCF
 _description: |-
   The EiffelTestCaseFinishedEvent declares that a previously started test case (declared by [EiffelTestCaseStartedEvent](./EiffelTestCaseStartedEvent.md)) has finished and reports the outcome.

--- a/definitions/EiffelTestCaseFinishedEvent/3.1.0.yml
+++ b/definitions/EiffelTestCaseFinishedEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestCaseFinishedEvent
+_version: 3.1.0
 _abbrev: TCF
 _description: |-
   The EiffelTestCaseFinishedEvent declares that a previously started test case (declared by [EiffelTestCaseStartedEvent](./EiffelTestCaseStartedEvent.md)) has finished and reports the outcome.

--- a/definitions/EiffelTestCaseFinishedEvent/3.2.0.yml
+++ b/definitions/EiffelTestCaseFinishedEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestCaseFinishedEvent
+_version: 3.2.0
 _abbrev: TCF
 _description: |-
   The EiffelTestCaseFinishedEvent declares that a previously started test case (declared by [EiffelTestCaseStartedEvent](./EiffelTestCaseStartedEvent.md)) has finished and reports the outcome.

--- a/definitions/EiffelTestCaseFinishedEvent/3.3.0.yml
+++ b/definitions/EiffelTestCaseFinishedEvent/3.3.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestCaseFinishedEvent
+_version: 3.3.0
 _abbrev: TCF
 _description: |-
   The EiffelTestCaseFinishedEvent declares that a previously started test case (declared by [EiffelTestCaseStartedEvent](./EiffelTestCaseStartedEvent.md)) has finished and reports the outcome.

--- a/definitions/EiffelTestCaseFinishedEvent/3.3.1.yml
+++ b/definitions/EiffelTestCaseFinishedEvent/3.3.1.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestCaseFinishedEvent
+_version: 3.3.1
 _abbrev: TCF
 _description: |-
   The EiffelTestCaseFinishedEvent declares that a previously started test case (declared by [EiffelTestCaseStartedEvent](./EiffelTestCaseStartedEvent.md)) has finished and reports the outcome.

--- a/definitions/EiffelTestCaseStartedEvent/1.0.0.yml
+++ b/definitions/EiffelTestCaseStartedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestCaseStartedEvent
+_version: 1.0.0
 _abbrev: TCS
 _description: The EiffelTestCaseStartedEvent declares that the execution
   of a test case has commenced. This event SHALL be preceded by a [EiffelTestCaseTriggeredEvent](./EiffelTestCaseTriggeredEvent.md),

--- a/definitions/EiffelTestCaseStartedEvent/1.1.0.yml
+++ b/definitions/EiffelTestCaseStartedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestCaseStartedEvent
+_version: 1.1.0
 _abbrev: TCS
 _description: The EiffelTestCaseStartedEvent declares that the execution
   of a test case has commenced. This event SHALL be preceded by a [EiffelTestCaseTriggeredEvent](./EiffelTestCaseTriggeredEvent.md),

--- a/definitions/EiffelTestCaseStartedEvent/2.0.0.yml
+++ b/definitions/EiffelTestCaseStartedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestCaseStartedEvent
+_version: 2.0.0
 _abbrev: TCS
 _description: The EiffelTestCaseStartedEvent declares that the execution
   of a test case has commenced. This event SHALL be preceded by a [EiffelTestCaseTriggeredEvent](./EiffelTestCaseTriggeredEvent.md),

--- a/definitions/EiffelTestCaseStartedEvent/3.0.0.yml
+++ b/definitions/EiffelTestCaseStartedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestCaseStartedEvent
+_version: 3.0.0
 _abbrev: TCS
 _description: The EiffelTestCaseStartedEvent declares that the execution
   of a test case has commenced. This event SHALL be preceded by a [EiffelTestCaseTriggeredEvent](./EiffelTestCaseTriggeredEvent.md),

--- a/definitions/EiffelTestCaseStartedEvent/3.1.0.yml
+++ b/definitions/EiffelTestCaseStartedEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestCaseStartedEvent
+_version: 3.1.0
 _abbrev: TCS
 _description: The EiffelTestCaseStartedEvent declares that the execution
   of a test case has commenced. This event SHALL be preceded by a [EiffelTestCaseTriggeredEvent](./EiffelTestCaseTriggeredEvent.md),

--- a/definitions/EiffelTestCaseStartedEvent/3.2.0.yml
+++ b/definitions/EiffelTestCaseStartedEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestCaseStartedEvent
+_version: 3.2.0
 _abbrev: TCS
 _description: The EiffelTestCaseStartedEvent declares that the execution
   of a test case has commenced. This event SHALL be preceded by a [EiffelTestCaseTriggeredEvent](./EiffelTestCaseTriggeredEvent.md),

--- a/definitions/EiffelTestCaseStartedEvent/3.3.0.yml
+++ b/definitions/EiffelTestCaseStartedEvent/3.3.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestCaseStartedEvent
+_version: 3.3.0
 _abbrev: TCS
 _description: The EiffelTestCaseStartedEvent declares that the execution
   of a test case has commenced. This event SHALL be preceded by a [EiffelTestCaseTriggeredEvent](./EiffelTestCaseTriggeredEvent.md),

--- a/definitions/EiffelTestCaseTriggeredEvent/1.0.0.yml
+++ b/definitions/EiffelTestCaseTriggeredEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestCaseTriggeredEvent
+_version: 1.0.0
 _abbrev: TCT
 _description: |-
   The EiffelTestCaseTriggeredEvent declares that the execution of a test case has been triggered, but not yet started. This can either be declared stand-alone or as part of an activity or test suite, using either a __CAUSE__ or a __CONTEXT__ link type, respectively.

--- a/definitions/EiffelTestCaseTriggeredEvent/1.1.0.yml
+++ b/definitions/EiffelTestCaseTriggeredEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestCaseTriggeredEvent
+_version: 1.1.0
 _abbrev: TCT
 _description: |-
   The EiffelTestCaseTriggeredEvent declares that the execution of a test case has been triggered, but not yet started. This can either be declared stand-alone or as part of an activity or test suite, using either a __CAUSE__ or a __CONTEXT__ link type, respectively.

--- a/definitions/EiffelTestCaseTriggeredEvent/2.0.0.yml
+++ b/definitions/EiffelTestCaseTriggeredEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestCaseTriggeredEvent
+_version: 2.0.0
 _abbrev: TCT
 _description: |-
   The EiffelTestCaseTriggeredEvent declares that the execution of a test case has been triggered, but not yet started. This can either be declared stand-alone or as part of an activity or test suite, using either a __CAUSE__ or a __CONTEXT__ link type, respectively.

--- a/definitions/EiffelTestCaseTriggeredEvent/3.0.0.yml
+++ b/definitions/EiffelTestCaseTriggeredEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestCaseTriggeredEvent
+_version: 3.0.0
 _abbrev: TCT
 _description: |-
   The EiffelTestCaseTriggeredEvent declares that the execution of a test case has been triggered, but not yet started. This can either be declared stand-alone or as part of an activity or test suite, using either a __CAUSE__ or a __CONTEXT__ link type, respectively.

--- a/definitions/EiffelTestCaseTriggeredEvent/3.1.0.yml
+++ b/definitions/EiffelTestCaseTriggeredEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestCaseTriggeredEvent
+_version: 3.1.0
 _abbrev: TCT
 _description: |-
   The EiffelTestCaseTriggeredEvent declares that the execution of a test case has been triggered, but not yet started. This can either be declared stand-alone or as part of an activity or test suite, using either a __CAUSE__ or a __CONTEXT__ link type, respectively.

--- a/definitions/EiffelTestCaseTriggeredEvent/3.2.0.yml
+++ b/definitions/EiffelTestCaseTriggeredEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestCaseTriggeredEvent
+_version: 3.2.0
 _abbrev: TCT
 _description: |-
   The EiffelTestCaseTriggeredEvent declares that the execution of a test case has been triggered, but not yet started. This can either be declared stand-alone or as part of an activity or test suite, using either a __CAUSE__ or a __CONTEXT__ link type, respectively.

--- a/definitions/EiffelTestCaseTriggeredEvent/3.3.0.yml
+++ b/definitions/EiffelTestCaseTriggeredEvent/3.3.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestCaseTriggeredEvent
+_version: 3.3.0
 _abbrev: TCT
 _description: |-
   The EiffelTestCaseTriggeredEvent declares that the execution of a test case has been triggered, but not yet started. This can either be declared stand-alone or as part of an activity or test suite, using either a __CAUSE__ or a __CONTEXT__ link type, respectively.

--- a/definitions/EiffelTestCaseTriggeredEvent/3.4.0.yml
+++ b/definitions/EiffelTestCaseTriggeredEvent/3.4.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestCaseTriggeredEvent
+_version: 3.4.0
 _abbrev: TCT
 _description: |-
   The EiffelTestCaseTriggeredEvent declares that the execution of a test case has been triggered, but not yet started. This can either be declared stand-alone or as part of an activity or test suite, using either a __CAUSE__ or a __CONTEXT__ link type, respectively.

--- a/definitions/EiffelTestCaseTriggeredEvent/3.5.0.yml
+++ b/definitions/EiffelTestCaseTriggeredEvent/3.5.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestCaseTriggeredEvent
+_version: 3.5.0
 _abbrev: TCT
 _description: |-
   The EiffelTestCaseTriggeredEvent declares that the execution of a test case has been triggered, but not yet started. This can either be declared stand-alone or as part of an activity or test suite, using either a __CAUSE__ or a __CONTEXT__ link type, respectively.

--- a/definitions/EiffelTestCaseTriggeredEvent/3.5.1.yml
+++ b/definitions/EiffelTestCaseTriggeredEvent/3.5.1.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestCaseTriggeredEvent
+_version: 3.5.1
 _abbrev: TCT
 _description: |-
   The EiffelTestCaseTriggeredEvent declares that the execution of a test case has been triggered, but not yet started. This can either be declared stand-alone or as part of an activity or test suite, using either a __CAUSE__ or a __CONTEXT__ link type, respectively.

--- a/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/1.0.0.yml
+++ b/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestExecutionRecipeCollectionCreatedEvent
+_version: 1.0.0
 _abbrev: TERCC
 _description: |-
   The EiffelTestExecutionRecipeCollectionCreatedEvent declares that a collection of test execution recipes has been created. In order to clarify what that means, several concepts need to be explained.

--- a/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/2.0.0.yml
+++ b/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestExecutionRecipeCollectionCreatedEvent
+_version: 2.0.0
 _abbrev: TERCC
 _description: |-
   The EiffelTestExecutionRecipeCollectionCreatedEvent declares that a collection of test execution recipes has been created. In order to clarify what that means, several concepts need to be explained.

--- a/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/2.1.0.yml
+++ b/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/2.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestExecutionRecipeCollectionCreatedEvent
+_version: 2.1.0
 _abbrev: TERCC
 _description: |-
   The EiffelTestExecutionRecipeCollectionCreatedEvent declares that a collection of test execution recipes has been created. In order to clarify what that means, several concepts need to be explained.

--- a/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/3.0.0.yml
+++ b/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestExecutionRecipeCollectionCreatedEvent
+_version: 3.0.0
 _abbrev: TERCC
 _description: |-
   The EiffelTestExecutionRecipeCollectionCreatedEvent declares that a collection of test execution recipes has been created. In order to clarify what that means, several concepts need to be explained.

--- a/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.0.0.yml
+++ b/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestExecutionRecipeCollectionCreatedEvent
+_version: 4.0.0
 _abbrev: TERCC
 _description: |-
   The EiffelTestExecutionRecipeCollectionCreatedEvent declares that a collection of test execution recipes has been created. In order to clarify what that means, several concepts need to be explained.

--- a/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.1.0.yml
+++ b/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestExecutionRecipeCollectionCreatedEvent
+_version: 4.1.0
 _abbrev: TERCC
 _description: |-
   The EiffelTestExecutionRecipeCollectionCreatedEvent declares that a collection of test execution recipes has been created. In order to clarify what that means, several concepts need to be explained.

--- a/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.1.1.yml
+++ b/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.1.1.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestExecutionRecipeCollectionCreatedEvent
+_version: 4.1.1
 _abbrev: TERCC
 _description: |-
   The EiffelTestExecutionRecipeCollectionCreatedEvent declares that a collection of test execution recipes has been created. In order to clarify what that means, several concepts need to be explained.

--- a/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.2.0.yml
+++ b/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestExecutionRecipeCollectionCreatedEvent
+_version: 4.2.0
 _abbrev: TERCC
 _description: |-
   The EiffelTestExecutionRecipeCollectionCreatedEvent declares that a collection of test execution recipes has been created. In order to clarify what that means, several concepts need to be explained.

--- a/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.3.0.yml
+++ b/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.3.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestExecutionRecipeCollectionCreatedEvent
+_version: 4.3.0
 _abbrev: TERCC
 _description: |-
   The EiffelTestExecutionRecipeCollectionCreatedEvent declares that a collection of test execution recipes has been created. In order to clarify what that means, several concepts need to be explained.

--- a/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.3.1.yml
+++ b/definitions/EiffelTestExecutionRecipeCollectionCreatedEvent/4.3.1.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestExecutionRecipeCollectionCreatedEvent
+_version: 4.3.1
 _abbrev: TERCC
 _description: |-
   The EiffelTestExecutionRecipeCollectionCreatedEvent declares that a collection of test execution recipes has been created. In order to clarify what that means, several concepts need to be explained.

--- a/definitions/EiffelTestSuiteFinishedEvent/1.0.0.yml
+++ b/definitions/EiffelTestSuiteFinishedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestSuiteFinishedEvent
+_version: 1.0.0
 _abbrev: TSF
 _description: |-
   The EiffelTestSuiteFinishedEvent declares that a previously started test suite (declared by [EiffelTestSuiteStartedEvent](./EiffelTestSuiteStartedEvent.md)) has finished and reports the outcome.

--- a/definitions/EiffelTestSuiteFinishedEvent/1.1.0.yml
+++ b/definitions/EiffelTestSuiteFinishedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestSuiteFinishedEvent
+_version: 1.1.0
 _abbrev: TSF
 _description: |-
   The EiffelTestSuiteFinishedEvent declares that a previously started test suite (declared by [EiffelTestSuiteStartedEvent](./EiffelTestSuiteStartedEvent.md)) has finished and reports the outcome.

--- a/definitions/EiffelTestSuiteFinishedEvent/2.0.0.yml
+++ b/definitions/EiffelTestSuiteFinishedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestSuiteFinishedEvent
+_version: 2.0.0
 _abbrev: TSF
 _description: |-
   The EiffelTestSuiteFinishedEvent declares that a previously started test suite (declared by [EiffelTestSuiteStartedEvent](./EiffelTestSuiteStartedEvent.md)) has finished and reports the outcome.

--- a/definitions/EiffelTestSuiteFinishedEvent/3.0.0.yml
+++ b/definitions/EiffelTestSuiteFinishedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestSuiteFinishedEvent
+_version: 3.0.0
 _abbrev: TSF
 _description: |-
   The EiffelTestSuiteFinishedEvent declares that a previously started test suite (declared by [EiffelTestSuiteStartedEvent](./EiffelTestSuiteStartedEvent.md)) has finished and reports the outcome.

--- a/definitions/EiffelTestSuiteFinishedEvent/3.1.0.yml
+++ b/definitions/EiffelTestSuiteFinishedEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestSuiteFinishedEvent
+_version: 3.1.0
 _abbrev: TSF
 _description: |-
   The EiffelTestSuiteFinishedEvent declares that a previously started test suite (declared by [EiffelTestSuiteStartedEvent](./EiffelTestSuiteStartedEvent.md)) has finished and reports the outcome.

--- a/definitions/EiffelTestSuiteFinishedEvent/3.2.0.yml
+++ b/definitions/EiffelTestSuiteFinishedEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestSuiteFinishedEvent
+_version: 3.2.0
 _abbrev: TSF
 _description: |-
   The EiffelTestSuiteFinishedEvent declares that a previously started test suite (declared by [EiffelTestSuiteStartedEvent](./EiffelTestSuiteStartedEvent.md)) has finished and reports the outcome.

--- a/definitions/EiffelTestSuiteFinishedEvent/3.3.0.yml
+++ b/definitions/EiffelTestSuiteFinishedEvent/3.3.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestSuiteFinishedEvent
+_version: 3.3.0
 _abbrev: TSF
 _description: |-
   The EiffelTestSuiteFinishedEvent declares that a previously started test suite (declared by [EiffelTestSuiteStartedEvent](./EiffelTestSuiteStartedEvent.md)) has finished and reports the outcome.

--- a/definitions/EiffelTestSuiteFinishedEvent/3.3.1.yml
+++ b/definitions/EiffelTestSuiteFinishedEvent/3.3.1.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestSuiteFinishedEvent
+_version: 3.3.1
 _abbrev: TSF
 _description: |-
   The EiffelTestSuiteFinishedEvent declares that a previously started test suite (declared by [EiffelTestSuiteStartedEvent](./EiffelTestSuiteStartedEvent.md)) has finished and reports the outcome.

--- a/definitions/EiffelTestSuiteStartedEvent/1.0.0.yml
+++ b/definitions/EiffelTestSuiteStartedEvent/1.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestSuiteStartedEvent
+_version: 1.0.0
 _abbrev: TSS
 _description: |-
   The EiffelTestSuiteStartedEvent declares that the execution of a test suite has started. This can either be declared stand-alone or as part of an activity or other test suite, using either a __CAUSE__ or a __CONTEXT__ link type, respectively.

--- a/definitions/EiffelTestSuiteStartedEvent/1.1.0.yml
+++ b/definitions/EiffelTestSuiteStartedEvent/1.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestSuiteStartedEvent
+_version: 1.1.0
 _abbrev: TSS
 _description: |-
   The EiffelTestSuiteStartedEvent declares that the execution of a test suite has started. This can either be declared stand-alone or as part of an activity or other test suite, using either a __CAUSE__ or a __CONTEXT__ link type, respectively.

--- a/definitions/EiffelTestSuiteStartedEvent/2.0.0.yml
+++ b/definitions/EiffelTestSuiteStartedEvent/2.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestSuiteStartedEvent
+_version: 2.0.0
 _abbrev: TSS
 _description: |-
   The EiffelTestSuiteStartedEvent declares that the execution of a test suite has started. This can either be declared stand-alone or as part of an activity or other test suite, using either a __CAUSE__ or a __CONTEXT__ link type, respectively.

--- a/definitions/EiffelTestSuiteStartedEvent/3.0.0.yml
+++ b/definitions/EiffelTestSuiteStartedEvent/3.0.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestSuiteStartedEvent
+_version: 3.0.0
 _abbrev: TSS
 _description: |-
   The EiffelTestSuiteStartedEvent declares that the execution of a test suite has started. This can either be declared stand-alone or as part of an activity or other test suite, using either a __CAUSE__ or a __CONTEXT__ link type, respectively.

--- a/definitions/EiffelTestSuiteStartedEvent/3.1.0.yml
+++ b/definitions/EiffelTestSuiteStartedEvent/3.1.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestSuiteStartedEvent
+_version: 3.1.0
 _abbrev: TSS
 _description: |-
   The EiffelTestSuiteStartedEvent declares that the execution of a test suite has started. This can either be declared stand-alone or as part of an activity or other test suite, using either a __CAUSE__ or a __CONTEXT__ link type, respectively.

--- a/definitions/EiffelTestSuiteStartedEvent/3.2.0.yml
+++ b/definitions/EiffelTestSuiteStartedEvent/3.2.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestSuiteStartedEvent
+_version: 3.2.0
 _abbrev: TSS
 _description: |-
   The EiffelTestSuiteStartedEvent declares that the execution of a test suite has started. This can either be declared stand-alone or as part of an activity or other test suite, using either a __CAUSE__ or a __CONTEXT__ link type, respectively.

--- a/definitions/EiffelTestSuiteStartedEvent/3.3.0.yml
+++ b/definitions/EiffelTestSuiteStartedEvent/3.3.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestSuiteStartedEvent
+_version: 3.3.0
 _abbrev: TSS
 _description: |-
   The EiffelTestSuiteStartedEvent declares that the execution of a test suite has started. This can either be declared stand-alone or as part of an activity or other test suite, using either a __CAUSE__ or a __CONTEXT__ link type, respectively.

--- a/definitions/EiffelTestSuiteStartedEvent/3.4.0.yml
+++ b/definitions/EiffelTestSuiteStartedEvent/3.4.0.yml
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 Ericsson AB and others.
+# Copyright 2017-2024 Ericsson AB and others.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # limitations under the License.
 ---
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelTestSuiteStartedEvent
+_version: 3.4.0
 _abbrev: TSS
 _description: |-
   The EiffelTestSuiteStartedEvent declares that the execution of a test suite has started. This can either be declared stand-alone or as part of an activity or other test suite, using either a __CAUSE__ or a __CONTEXT__ link type, respectively.

--- a/eiffel-syntax-and-usage/event-schemas.md
+++ b/eiffel-syntax-and-usage/event-schemas.md
@@ -1,5 +1,5 @@
 <!---
-   Copyright 2022-2023 Axis Communications AB and others.
+   Copyright 2022-2024 Axis Communications AB and others.
    For a full list of individual contributors, please see the commit history.
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,6 +25,8 @@ Both schemas and documentation files are generated from _schema definition files
 
 | Key             | Description             |
 | --------------- | ----------------------- |
+| `_name`         | The name of the type, e.g. "EiffelCompositionDefinedEvent". This string must match the name of the parent directory. |
+| `_version`      | The version of the event or other type, e.g. "3.1.0". This string must match the name of the definition file, except for the filename suffix. |
 | `_abbrev`       | The abbreviation of the event name, e.g. "CD" for EiffelCompositionDefinedEvent. |
 | `_description`  | An overall description of the event. |
 | `_links`        | An object describing the valid link types for the event. |
@@ -66,6 +68,8 @@ Here's a minimal example of a schema definition file:
 
 ```yaml
 $schema: http://json-schema.org/draft-04/schema#
+_name: EiffelSomethingHappenedEvent
+_version: 1.0.0
 _abbrev: SH
 _description: The EiffelSomethingHappenedEvent declares that something happened.
 type: object

--- a/generate_docs.py
+++ b/generate_docs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2022 Axis Communications AB.
+# Copyright 2022-2024 Axis Communications AB.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -142,10 +142,10 @@ def _main():
         print(filename)
         input_path = Path(filename)
         schema = definition_loader.load(input_path)
-        output_path = (_OUTPUT_ROOT_PATH / input_path.parent.name).with_suffix(".md")
+        output_path = _OUTPUT_ROOT_PATH / (schema["_name"] + ".md")
         context = {
-            "type": input_path.parent.name,
-            "version": input_path.stem,
+            "type": schema["_name"],
+            "version": schema["_version"],
             "description": schema.get("_description", ""),
             "abbrev": schema.get("_abbrev", ""),
             "links": schema.get("_links", {}),

--- a/generate_schemas.py
+++ b/generate_schemas.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2022 Axis Communications AB.
+# Copyright 2022-2024 Axis Communications AB.
 # For a full list of individual contributors, please see the commit history.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -53,8 +53,8 @@ def _main():
         # the generic meta definition from one of the files in
         # definitions/EiffelMetaProperty. Patch the definitions of
         # meta.type and meta.version based on the event type and version.
-        meta_type = input_path.parent.name
-        meta_version = input_path.stem
+        meta_type = event_def["_name"]
+        meta_version = event_def["_version"]
         meta_properties = event_def["properties"]["meta"]["properties"]
         meta_properties["type"]["enum"] = [meta_type]
         meta_properties["version"]["enum"] = [meta_version]
@@ -62,9 +62,7 @@ def _main():
 
         _strip_extra_keys(event_def)
 
-        output_path = (
-            _OUTPUT_ROOT_PATH / input_path.parent.name / input_path.name
-        ).with_suffix(".json")
+        output_path = _OUTPUT_ROOT_PATH / meta_type / (meta_version + ".json")
         with output_path.open(mode="w") as output_file:
             json.dump(event_def, output_file, indent=2)
             output_file.write("\n")


### PR DESCRIPTION
### Applicable Issues
Fixes #341

### Description of the Change
Up to now we've been relying on the directory structure and filenames to determine the name and version of a definition file for an event or some other type. There are advantages to this, but also the drawback    that it's clunky to work with and that the files always must remain in    this structure, i.e. you can't just transfer the contents of a file over    some channel or protocol and expect the receiver to be able to make    sense of it.

The new _name and _version key are introduced in the definition file    format and all existing files are updated to include them. We also add    a test that makes sure that the contents of those keys matches the    path to the file.

### Alternate Designs
None.

### Benefits
No more dependency to knowing being able to parse the filepath of a file.

### Possible Drawbacks
When copying an existing file to create a new version you also need to update the _version key.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
