### PR TITLE
generate_manifest.py: Use versions module

### DIFF
--- a/versions.py
+++ b/versions.py
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""The versions module contains functions for discovering definition files."""
+"""The versions module contains functions for discovering definition
+files and schema files.
+"""
 
 import os
 import subprocess
@@ -27,10 +29,11 @@ import semver
 def latest_in_gitref(
     committish: str, gitdir: Path, subdir: Path
 ) -> Dict[str, semver.version.Version]:
-    """Lists the definition files found under a given subdirectory of a
-    git at a given point in time (described by a committish, e.g. a
-    SHA-1, tag, or branch reference) and returns a dict that maps each
-    typename (e.g. EiffelArtifactCreatedEvent) to the latest version found.
+    """Lists the definition or schema files found under a given
+    subdirectory of a git at a given point in time (described by a
+    committish, e.g. a SHA-1, tag, or branch reference) and returns a
+    dict that maps each typename (e.g. EiffelArtifactCreatedEvent) to
+    the latest version found.
     """
     return _latest_versions(
         Path(line)
@@ -42,20 +45,20 @@ def latest_in_gitref(
             .decode("utf-8")
             .splitlines()
         )
-        if Path(line).suffix == ".yml"
+        if Path(line).suffix in (".json", ".yml")
     )
 
 
 def latest_in_dir(path: Path) -> Dict[str, semver.version.Version]:
-    """Inspects the definition files found under a given path and returns
-    a dict that maps each typename (e.g. EiffelArtifactCreatedEvent) to
-    its latest version found.
+    """Inspects the definition or schema files found under
+    a given path and returns a dict that maps each typename
+    (e.g. EiffelArtifactCreatedEvent) to its latest version found.
     """
     return _latest_versions(
         Path(current) / f
         for current, _, files in os.walk(path)
         for f in files
-        if Path(f).suffix == ".yml"
+        if Path(f).suffix in (".json", ".yml")
     )
 
 


### PR DESCRIPTION
### Applicable Issues
#319

### Description of the Change
When the versions module was introduced in commit e4762e9, the code in generate_manifest.py for listing the latest version of each type went unnoticed. With a slight change to versions.py to allow discovering schema file and not just definitions files we were able to use that module and delete some code.

### Alternate Designs
None.

### Possible Drawbacks
None I can think of.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
