### PR TITLE
Lock version of markdownlint-cli and fix violations

### DIFF
--- a/.markdown-lint.yml
+++ b/.markdown-lint.yml
@@ -30,9 +30,10 @@
 # Rules by tags #
 #################
 
+# MD041/first-line-heading/first-line-h1
 # First line in a file being a top-level heading collides with starting
 # each file with a copyright statement.
-first-line-h1: false
+first-line-h1: false # Affects 45 files
 
 # MD013/line-length - Line length
 line-length:

--- a/.markdown-lint.yml
+++ b/.markdown-lint.yml
@@ -30,6 +30,10 @@
 # Rules by tags #
 #################
 
+# First line in a file being a top-level heading collides with starting
+# each file with a copyright statement.
+first-line-h1: false
+
 # MD013/line-length - Line length
 line-length:
     line_length: 900 # Arbitrary length to catch the worst. Setting this to 120 affects 500 lines

--- a/tox.ini
+++ b/tox.ini
@@ -79,4 +79,4 @@ changedir = {toxinidir}
 allowlist_externals =
     npx
 commands =
-    npx markdownlint-cli -c .markdown-lint.yml *.md **/*.md
+    npx markdownlint-cli@v0.34.0 -c .markdown-lint.yml *.md **/*.md


### PR DESCRIPTION
### Applicable Issues
Fixes #397

### Description of the Change
markdownlint-cli was using a floating version, and since this linter was introduced additional rules have been added so now the linting fails on the master branch. Lock the version to the currently latest version and disable the rule that we didn't comply with (since addressing it properly would be rather intrusive).

### Alternate Designs
We could lock the version to an older version that doesn't require additional changes (e.g. the version that was current when markdownlint was introduced).

### Possible Drawbacks
We don't automatically get the latest version of the tool, but CI reliability is arguably more important.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com>
